### PR TITLE
Fix matrix animation reset on mobile scroll

### DIFF
--- a/components/matrix-rain.tsx
+++ b/components/matrix-rain.tsx
@@ -3,12 +3,10 @@
 import React, { useEffect, useRef } from 'react'
 import styles from './matrix-rain.module.css'
 import { useTheme } from 'next-themes'
-import { useWindowSize } from 'react-use'
 
 const MatrixRain: React.FC = () => {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const { theme, resolvedTheme } = useTheme()
-  const { width, height } = useWindowSize()
 
   const isDarkMode =
     theme === 'system' ? resolvedTheme === 'dark' : theme === 'dark'
@@ -73,7 +71,7 @@ const MatrixRain: React.FC = () => {
       // Optionally clear canvas on cleanup
       if (ctx) ctx.clearRect(0, 0, canvas.width, canvas.height)
     }
-  }, [isDarkMode, width, height])
+  }, [isDarkMode])
 
   return <div className={styles.matrixContainer} ref={containerRef}></div>
 }


### PR DESCRIPTION
Remove useWindowSize hook dependency that was causing the matrix animation to reset when scrolling on mobile. The browser address bar showing/hiding changes window height, which was triggering unnecessary re-renders. Animation now only resets on theme changes.