### PR TITLE
fix: improve Skills tiles visibility in light mode

### DIFF
--- a/components/tile.tsx
+++ b/components/tile.tsx
@@ -10,7 +10,7 @@ export interface tileProps {
 export const Tile = ({ icon, text, link }: tileProps) => {
   return (
     <a href={link} target="_blank" rel="noreferrer">
-      <div className="flex flex-col items-center justify-center rounded-lg border border-gray-700 bg-slate-50 py-4 hover:border-blue-600 hover:text-blue-600 dark:bg-slate-950">
+      <div className="flex flex-col items-center justify-center rounded-lg border border-gray-300 bg-slate-50 py-4 text-slate-800 hover:border-blue-600 hover:text-blue-600 dark:border-gray-700 dark:bg-slate-950 dark:text-slate-200">
         {icon && <FontAwesomeIcon icon={icon} className="" size="2xl" />}
         {text && <p className="pt-2 text-center">{text}</p>}
       </div>


### PR DESCRIPTION
## Summary
- Adds explicit `text-slate-800` color for light mode to make skill tile text visible
- Changes `border-gray-700` to `border-gray-300` for better light mode contrast
- Adds `dark:text-slate-200` for explicit dark mode text color  
- Adds `dark:border-gray-700` to preserve dark mode styling

## Test plan
- [ ] Verify text is visible in light mode on skill tiles
- [ ] Verify text is visible in dark mode on skill tiles  
- [ ] Verify border colors look appropriate in both modes
- [ ] Verify hover states still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)