### PR TITLE
Career + Systems redesign — Option 2: "The Machine" (three.js equipment rack + playable cutaway)

### DIFF
--- a/app/career/career-data.ts
+++ b/app/career/career-data.ts
@@ -76,8 +76,14 @@ export const rackUnits: RackUnit[] = [
     metrics: [
       { label: 'Program', value: 'Turing School of Software and Design, 2017' },
       { label: 'Degree', value: 'B.A. Economics, University of Kansas, 2015' },
-      { label: 'Freelance', value: 'U-Hoops — WordPress → React/Redux + Express + MongoDB' },
-      { label: 'Earlier', value: 'Project manager, JDB Capital (four properties)' }
+      {
+        label: 'Freelance',
+        value: 'U-Hoops — WordPress → React/Redux + Express + MongoDB'
+      },
+      {
+        label: 'Earlier',
+        value: 'Project manager, JDB Capital (four properties)'
+      }
     ],
     stack: ['React', 'Redux', 'Express', 'MongoDB', 'JavaScript'],
     net: ['bnr'],
@@ -102,7 +108,10 @@ export const rackUnits: RackUnit[] = [
       { label: 'Title', value: 'Solutions Architect' },
       { label: 'Since', value: 'July 2018' },
       { label: 'Mode', value: 'Embedded in client engineering teams' },
-      { label: 'Channels', value: 'Apple (2018–2020) · Chick-fil-A (2020–2022)' }
+      {
+        label: 'Channels',
+        value: 'Apple (2018–2020) · Chick-fil-A (2020–2022)'
+      }
     ],
     stack: ['Architecture', 'Client teams', 'Code review', 'Estimation'],
     net: ['apple', 'patch'],
@@ -131,7 +140,10 @@ export const rackUnits: RackUnit[] = [
       { label: 'Uptime', value: '100% through the growth' },
       { label: 'Runtime', value: 'Node 5 → Node 12, ES5 → ES6' },
       { label: 'Front end', value: 'Angular 1 → Vue rewrite' },
-      { label: 'Shipped', value: 'Apple Card integration + launch coordination' }
+      {
+        label: 'Shipped',
+        value: 'Apple Card integration + launch coordination'
+      }
     ],
     stack: ['Node', 'JavaScript', 'Vue', 'Express', 'MongoDB', 'AWS'],
     net: ['cfa'],
@@ -158,12 +170,26 @@ export const rackUnits: RackUnit[] = [
     metrics: [
       { label: 'Revenue', value: '<$1M/day → $5M/day (2022)' },
       { label: 'Partners', value: 'DoorDash · UberEats · Grubhub' },
-      { label: 'Combo meals', value: 'UberEats combos → ~10% higher revenue per order' },
+      {
+        label: 'Combo meals',
+        value: 'UberEats combos → ~10% higher revenue per order'
+      },
       { label: 'iOS', value: 'DoorDash checkout inside the Chick-fil-A app' },
-      { label: 'Infrastructure', value: 'Migrated the project to AWS CloudFormation' },
+      {
+        label: 'Infrastructure',
+        value: 'Migrated the project to AWS CloudFormation'
+      },
       { label: 'Operations', value: 'Logging, monitoring, alerting rebuilt' }
     ],
-    stack: ['Node', 'Go', 'TypeScript', 'AWS', 'CloudFormation', 'DynamoDB', 'Datadog'],
+    stack: [
+      'Node',
+      'Go',
+      'TypeScript',
+      'AWS',
+      'CloudFormation',
+      'DynamoDB',
+      'Datadog'
+    ],
     net: ['patch'],
     wave: 'packet'
   },
@@ -224,7 +250,10 @@ export const rackUnits: RackUnit[] = [
     metrics: [
       { label: 'Location', value: 'Raleigh, North Carolina' },
       { label: 'Email', value: 'devjbull@gmail.com' },
-      { label: 'Looking for', value: 'Platform, integrations, modernisation at scale' },
+      {
+        label: 'Looking for',
+        value: 'Platform, integrations, modernisation at scale'
+      },
       { label: 'Status', value: 'Open to conversations' }
     ],
     stack: [],
@@ -251,7 +280,12 @@ export function unitCenterY(index: number) {
   return RACK_HEIGHT / 2 - (index + 0.5) * UNIT_PITCH
 }
 
-export type Patch = { from: string; to: string; fromIndex: number; toIndex: number }
+export type Patch = {
+  from: string
+  to: string
+  fromIndex: number
+  toIndex: number
+}
 
 export const patches: Patch[] = rackUnits.flatMap((unit, index) =>
   unit.net

--- a/app/career/career-data.ts
+++ b/app/career/career-data.ts
@@ -1,7 +1,7 @@
-// Career content for /career. Every fact here comes from Devon's own resumes.
-// TODO(devon): the resume of record ends in 2022. Confirm current title/level and
-// what client work has happened since Chick-fil-A, then extend SLOT 03 and add slots.
-// TODO(devon): confirm there is no NDA problem naming Apple and Chick-fil-A here.
+// Career content for /career. Every fact here comes from Devon's own resumes and
+// his own follow-up corrections.
+// TODO(devon): exact start/end months for the two most recent Apple eras (SLOT 06, SLOT 07).
+// TODO(devon): current title at Stellar Elements (the 2022 resume said Solutions Architect).
 // TODO(devon): decide whether to link a current resume PDF from the OUTPUT slot.
 
 export type Meter = {
@@ -66,7 +66,7 @@ export const rackUnits: RackUnit[] = [
     role: 'Retune · economics → engineering',
     face: ['TURING SCHOOL', 'FE DEV'],
     headline: 'No CS degree. That is a feature.',
-    body: 'B.A. Economics from the University of Kansas in 2015, property management before that, a startup after it, then Turing School of Software and Design in 2017 for front-end development. I came into engineering through the business door, which is why I still ask what a feature is worth before I ask how it should be built. In parallel I freelanced: rewriting U-Hoops from a WordPress site into React/Redux with an Express and MongoDB backend, plus accounts, tour management and a message board.',
+    body: 'B.A. Economics from the University of Kansas in 2015, property management before that, a startup after it, then Turing School of Software and Design in 2017. I came into engineering through the business door, which is why I still ask what a feature is worth before I ask how it should be built. In parallel I freelanced: rewriting U-Hoops from a WordPress site into React/Redux with an Express and MongoDB backend, plus accounts, tour management and a message board.',
     meter: {
       label: 'Computer science degrees',
       from: 0,
@@ -86,44 +86,55 @@ export const rackUnits: RackUnit[] = [
       }
     ],
     stack: ['React', 'Redux', 'Express', 'MongoDB', 'JavaScript'],
-    net: ['bnr'],
+    net: ['firm'],
     wave: 'clock'
   },
   {
-    id: 'bnr',
+    id: 'firm',
     slot: '03',
-    org: 'Big Nerd Ranch',
+    org: 'Stellar Elements',
     window: 'Jul 2018 → present',
-    role: 'Host frame · Solutions Architect',
-    face: ['BIG NERD RANCH', 'SOLUTIONS ARCH'],
-    headline: 'One firm. Every client system patched through it.',
-    body: 'Big Nerd Ranch is the one consulting firm on my résumé — Solutions Architect since July 2018. Consulting means being dropped into a codebase other people have lived in for years and being useful inside the first sprint: read the system, find the seam, ship one small correct change, earn the larger one. Both client channels below run through this frame.',
+    role: 'Host frame · one firm, seven years',
+    face: ['STELLAR ELEMENTS', 'EX BIG NERD RANCH'],
+    headline: 'One firm for seven years, and the work kept getting harder.',
+    body: 'Stellar Elements — formerly Big Nerd Ranch, now an Amdocs company — has been my employer since July 2018, through a rebrand and an acquisition. Every unit above slot 03 is a client engagement that ran through this frame: backend lead at consumer scale, then engineering lead through a hypergrowth integration crisis, then sole owner of an internal product at Apple, then platform and developer-experience work. Same firm, escalating scope. Being handed the next hard thing repeatedly is the part of the résumé I am proudest of.',
     meter: {
-      label: 'Consulting firms on my résumé',
+      label: 'Years at one firm',
       from: 0,
-      to: 1,
-      note: 'Big Nerd Ranch, July 2018 to present. Two long client engagements.'
+      to: 7,
+      note: 'July 2018 to present, through the Big Nerd Ranch → Stellar Elements transition.'
     },
     metrics: [
-      { label: 'Title', value: 'Solutions Architect' },
-      { label: 'Since', value: 'July 2018' },
-      { label: 'Mode', value: 'Embedded in client engineering teams' },
       {
-        label: 'Channels',
-        value: 'Apple (2018–2020) · Chick-fil-A (2020–2022)'
+        label: 'Employer',
+        value: 'Stellar Elements (formerly Big Nerd Ranch), an Amdocs company'
+      },
+      { label: 'Since', value: 'July 2018 — present' },
+      {
+        label: 'Last stated title',
+        value: 'Solutions Architect (2022 résumé)'
+      },
+      {
+        label: 'Clients',
+        value: 'Apple (2018–present, three eras) · Chick-fil-A (2020–2022)'
       }
     ],
-    stack: ['Architecture', 'Client teams', 'Code review', 'Estimation'],
-    net: ['apple', 'patch'],
+    stack: [
+      'Architecture',
+      'Product engineering',
+      'Client teams',
+      'Code review'
+    ],
+    net: ['apple1', 'patch'],
     wave: 'rail'
   },
   {
-    id: 'apple',
+    id: 'apple1',
     slot: '04',
-    org: 'Apple',
+    org: 'Apple · chatbot',
     window: '2018 → 2020',
-    role: 'Client channel 01 · backend lead',
-    face: ['APPLE', 'BACKEND LEAD'],
+    role: 'Apple era 1 · backend lead',
+    face: ['APPLE / CHATBOT', 'BACKEND LEAD'],
     headline: 'One million users to fifteen million, and a 30× faster page.',
     body: 'Backend lead on Apple’s chatbot platform. I implemented the Apple Card integration and helped coordinate its launch, helped move the front end from Angular 1 to Vue, refactored a critical service from ES5 to ES6, and helped drag the runtime from Node 5 to Node 12 — the unglamorous modernisation that has to happen underneath a product nobody is allowed to take offline. Page load went from sixty seconds to two. Traffic went from one million users to fifteen million with 100% uptime.',
     meter: {
@@ -154,7 +165,7 @@ export const rackUnits: RackUnit[] = [
     slot: '05',
     org: 'Chick-fil-A',
     window: '2020 → 2022',
-    role: 'Client channel 02 · project engineering lead',
+    role: 'Client channel · project engineering lead',
     face: ['CHICK-FIL-A', 'ENG LEAD · 3PD'],
     headline: 'Under $1M a day to $5M a day, without dropping the orders.',
     body: 'Project engineering lead for third-party delivery: DoorDash, UberEats and Grubhub patched into Chick-fil-A’s ordering platform. Covid turned a side channel into a main one, and the number that mattered was revenue per day — under one million to five million by 2022 — while every partner integration kept working. I shipped combo meals on UberEats, worth roughly ten percent more per order; worked with DoorDash’s engineers to put DoorDash checkout inside the Chick-fil-A iOS app; oversaw migrating the project’s infrastructure to AWS CloudFormation; and rebuilt logging, monitoring and alerting so we saw a partner outage before the partner called us.',
@@ -190,18 +201,77 @@ export const rackUnits: RackUnit[] = [
       'DynamoDB',
       'Datadog'
     ],
-    net: ['patch'],
+    net: ['apple2'],
     wave: 'packet'
   },
   {
-    id: 'patch',
+    id: 'apple2',
     slot: '06',
+    org: 'Apple · cloud resources UI',
+    window: '~2022 → ~2024',
+    role: 'Apple era 2 · sole engineer',
+    face: ['APPLE / CLOUD UI', 'SOLO · 2 YEARS'],
+    headline: 'Two years as the only engineer on the product.',
+    body: 'Sole engineer owning Apple’s React and TypeScript UI for managing third-party cloud resources: design decisions, build, ship, maintain, support — no team to hide behind and no one else to hand the ambiguous part to. Two years of being the person who decides what the interface should do, then makes it do that, inside a company with a very specific bar for what shipped software feels like.',
+    meter: {
+      label: 'Engineers on the product',
+      from: 0,
+      to: 1,
+      note: 'One. Me, for roughly two years, on a real internal product at Apple.'
+    },
+    metrics: [
+      { label: 'Ownership', value: 'Sole engineer, end to end' },
+      {
+        label: 'Surface',
+        value: 'UI for managing third-party cloud resources'
+      },
+      { label: 'Stack', value: 'React · TypeScript' },
+      { label: 'Duration', value: '≈ 2 years' }
+    ],
+    stack: ['React', 'TypeScript', 'Design systems', 'Cloud APIs'],
+    net: ['apple3'],
+    wave: 'pwm'
+  },
+  {
+    id: 'apple3',
+    slot: '07',
+    org: 'Apple · developer portal',
+    window: '~2024 → present',
+    role: 'Apple era 3 · product + platform',
+    face: ['APPLE / DEV PORTAL', 'CURRENT WORK'],
+    headline: 'The place Apple engineers go to manage their clouds.',
+    body: 'Building Apple’s internal cloud website: where users manage their clouds across Apple-internal resources and third-party providers, in React and TypeScript. It is now expanding into a complete Developer Portal experience — the surface other engineers work through every day, which is the kind of product where a bad decision costs everybody an hour a week and a good one is invisible. Developer-experience product work at Apple scale, and the current job.',
+    meter: {
+      label: 'Years with Apple as a client',
+      from: 0,
+      to: 7,
+      note: 'Three eras since 2018: chatbot backend, solo cloud UI, now the developer portal.'
+    },
+    metrics: [
+      {
+        label: 'Product',
+        value: 'Apple internal cloud website → Developer Portal'
+      },
+      {
+        label: 'Scope',
+        value: 'Apple-internal and third-party cloud providers'
+      },
+      { label: 'Stack', value: 'React · TypeScript' },
+      { label: 'Status', value: 'Current engagement' }
+    ],
+    stack: ['React', 'TypeScript', 'Developer experience', 'Internal platform'],
+    net: ['patch'],
+    wave: 'clock'
+  },
+  {
+    id: 'patch',
+    slot: '08',
     org: 'Patch field',
     window: 'Current',
     role: 'Stack · chosen by access pattern',
     face: ['PATCH FIELD', 'STACK'],
     headline: 'The stack, as actually used in production.',
-    body: 'JavaScript, TypeScript, Go, Node, Express, Vue and React on the application side. MongoDB, DynamoDB and Postgres on the data side, picked by access pattern rather than by preference. AWS, Docker, Kubernetes and GitHub Actions to ship it; Datadog, Splunk and OpsGenie to watch it; Jira and Confluence because consulting is also a paperwork job.',
+    body: 'React and TypeScript on the product side, with Vue and JavaScript in the history and Node, Express and Go behind it. MongoDB, DynamoDB and Postgres on the data side, picked by access pattern rather than by preference. AWS, Docker, Kubernetes and GitHub Actions to ship it; Datadog, Splunk and OpsGenie to watch it; Jira and Confluence because client work is also a paperwork job.',
     meter: {
       label: 'Datastores run in production',
       from: 0,
@@ -209,19 +279,19 @@ export const rackUnits: RackUnit[] = [
       note: 'MongoDB, DynamoDB, Postgres — three different access-pattern bets.'
     },
     metrics: [
-      { label: 'Languages', value: 'JavaScript · TypeScript · Go' },
-      { label: 'Frameworks', value: 'Node · Express · Vue · React · Mongoose' },
+      { label: 'Front end', value: 'React · TypeScript · Vue' },
+      { label: 'Back end', value: 'Node · Express · Go · Mongoose' },
       { label: 'Data', value: 'MongoDB · DynamoDB · Postgres' },
       { label: 'Ship', value: 'AWS · Docker · Kubernetes · GitHub Actions' },
       { label: 'Watch', value: 'Datadog · Splunk · OpsGenie' }
     ],
     stack: [
-      'JavaScript',
+      'React',
       'TypeScript',
+      'JavaScript',
       'Go',
       'Node',
       'Vue',
-      'React',
       'MongoDB',
       'DynamoDB',
       'Postgres',
@@ -230,17 +300,17 @@ export const rackUnits: RackUnit[] = [
       'Datadog'
     ],
     net: ['out'],
-    wave: 'pwm'
+    wave: 'rail'
   },
   {
     id: 'out',
-    slot: '07',
+    slot: '09',
     org: 'Output',
     window: 'Open',
-    role: 'Output jack · contact',
+    role: 'Output jack · product engineer',
     face: ['OUTPUT', 'PATCH IN'],
-    headline: 'Patch in.',
-    body: 'Raleigh, North Carolina. Interested in high-traffic consumer platforms, integration work between systems that were never designed to talk to each other, and legacy modernisation that has to happen while the thing stays up.',
+    headline: 'Product engineer. Patch in.',
+    body: 'Raleigh, North Carolina. The work I want is the work this rack is made of: product engineering where somebody has to hold the interface, the service behind it and the question of whether it was worth building — internal platforms and developer experience, consumer products at scale, or the integration problem between systems that were never designed to talk.',
     meter: {
       label: 'Open channels',
       from: 0,
@@ -248,12 +318,9 @@ export const rackUnits: RackUnit[] = [
       note: 'devjbull@gmail.com — usually a same-day reply.'
     },
     metrics: [
+      { label: 'Target role', value: 'Product engineer / senior full-stack' },
       { label: 'Location', value: 'Raleigh, North Carolina' },
       { label: 'Email', value: 'devjbull@gmail.com' },
-      {
-        label: 'Looking for',
-        value: 'Platform, integrations, modernisation at scale'
-      },
       { label: 'Status', value: 'Open to conversations' }
     ],
     stack: [],
@@ -273,7 +340,7 @@ export const unitsById = Object.fromEntries(
 ) as Record<string, RackUnit>
 
 export const RACK_WIDTH = 12
-export const RACK_HEIGHT = 8
+export const RACK_HEIGHT = 10.4
 export const UNIT_PITCH = RACK_HEIGHT / rackUnits.length
 
 export function unitCenterY(index: number) {

--- a/app/career/career-data.ts
+++ b/app/career/career-data.ts
@@ -1,0 +1,270 @@
+// Career content for /career. Every fact here comes from Devon's own resumes.
+// TODO(devon): the resume of record ends in 2022. Confirm current title/level and
+// what client work has happened since Chick-fil-A, then extend SLOT 03 and add slots.
+// TODO(devon): confirm there is no NDA problem naming Apple and Chick-fil-A here.
+// TODO(devon): decide whether to link a current resume PDF from the OUTPUT slot.
+
+export type Meter = {
+  label: string
+  from: number
+  to: number
+  prefix?: string
+  suffix?: string
+  decimals?: number
+  note: string
+}
+
+export type RackUnit = {
+  id: string
+  slot: string
+  org: string
+  window: string
+  role: string
+  face: string[]
+  headline: string
+  body: string
+  meter: Meter
+  metrics: { label: string; value: string }[]
+  stack: string[]
+  /** Patch cables out of this unit. */
+  net: string[]
+  links?: { label: string; href: string }[]
+  wave: 'ramp' | 'clock' | 'burst' | 'packet' | 'rail' | 'handshake' | 'pwm'
+}
+
+export const rackUnits: RackUnit[] = [
+  {
+    id: 'haller',
+    slot: '01',
+    org: 'Haller',
+    window: '2015',
+    role: 'Founder unit · COO',
+    face: ['HALLER', 'COO / FOUNDER'],
+    headline: 'I built the prototype before I could build software.',
+    body: 'Haller started as a business plan I wrote and pitched into a startup accelerator — and got in. There was no engineer on the team, so I taught myself Sketch and enough Swift to build the prototype myself. That is where the operator became the builder: the fastest way to learn whether an idea is real is to make the thing and put it in front of someone.',
+    meter: {
+      label: 'Engineers on staff',
+      from: 0,
+      to: 1,
+      note: 'Zero, then me. Accepted into a business accelerator.'
+    },
+    metrics: [
+      { label: 'Role', value: 'COO, co-founder' },
+      { label: 'Outcome', value: 'Accepted into a business accelerator' },
+      { label: 'Built', value: 'Prototype, self-taught Sketch + Swift' },
+      { label: 'Year', value: '2015' }
+    ],
+    stack: ['Sketch', 'Swift (basic)', 'Business plan', 'Pitching'],
+    net: ['turing'],
+    wave: 'ramp'
+  },
+  {
+    id: 'turing',
+    slot: '02',
+    org: 'Turing School',
+    window: '2017',
+    role: 'Retune · economics → engineering',
+    face: ['TURING SCHOOL', 'FE DEV'],
+    headline: 'No CS degree. That is a feature.',
+    body: 'B.A. Economics from the University of Kansas in 2015, property management before that, a startup after it, then Turing School of Software and Design in 2017 for front-end development. I came into engineering through the business door, which is why I still ask what a feature is worth before I ask how it should be built. In parallel I freelanced: rewriting U-Hoops from a WordPress site into React/Redux with an Express and MongoDB backend, plus accounts, tour management and a message board.',
+    meter: {
+      label: 'Computer science degrees',
+      from: 0,
+      to: 0,
+      note: 'Meter reads zero on purpose. B.A. Economics, Kansas 2015 · Turing 2017.'
+    },
+    metrics: [
+      { label: 'Program', value: 'Turing School of Software and Design, 2017' },
+      { label: 'Degree', value: 'B.A. Economics, University of Kansas, 2015' },
+      { label: 'Freelance', value: 'U-Hoops — WordPress → React/Redux + Express + MongoDB' },
+      { label: 'Earlier', value: 'Project manager, JDB Capital (four properties)' }
+    ],
+    stack: ['React', 'Redux', 'Express', 'MongoDB', 'JavaScript'],
+    net: ['bnr'],
+    wave: 'clock'
+  },
+  {
+    id: 'bnr',
+    slot: '03',
+    org: 'Big Nerd Ranch',
+    window: 'Jul 2018 → present',
+    role: 'Host frame · Solutions Architect',
+    face: ['BIG NERD RANCH', 'SOLUTIONS ARCH'],
+    headline: 'One firm. Every client system patched through it.',
+    body: 'Big Nerd Ranch is the one consulting firm on my résumé — Solutions Architect since July 2018. Consulting means being dropped into a codebase other people have lived in for years and being useful inside the first sprint: read the system, find the seam, ship one small correct change, earn the larger one. Both client channels below run through this frame.',
+    meter: {
+      label: 'Consulting firms on my résumé',
+      from: 0,
+      to: 1,
+      note: 'Big Nerd Ranch, July 2018 to present. Two long client engagements.'
+    },
+    metrics: [
+      { label: 'Title', value: 'Solutions Architect' },
+      { label: 'Since', value: 'July 2018' },
+      { label: 'Mode', value: 'Embedded in client engineering teams' },
+      { label: 'Channels', value: 'Apple (2018–2020) · Chick-fil-A (2020–2022)' }
+    ],
+    stack: ['Architecture', 'Client teams', 'Code review', 'Estimation'],
+    net: ['apple', 'patch'],
+    wave: 'rail'
+  },
+  {
+    id: 'apple',
+    slot: '04',
+    org: 'Apple',
+    window: '2018 → 2020',
+    role: 'Client channel 01 · backend lead',
+    face: ['APPLE', 'BACKEND LEAD'],
+    headline: 'One million users to fifteen million, and a 30× faster page.',
+    body: 'Backend lead on Apple’s chatbot platform. I implemented the Apple Card integration and helped coordinate its launch, helped move the front end from Angular 1 to Vue, refactored a critical service from ES5 to ES6, and helped drag the runtime from Node 5 to Node 12 — the unglamorous modernisation that has to happen underneath a product nobody is allowed to take offline. Page load went from sixty seconds to two. Traffic went from one million users to fifteen million with 100% uptime.',
+    meter: {
+      label: 'Users on the platform',
+      from: 1,
+      to: 15,
+      suffix: 'M',
+      decimals: 1,
+      note: '1M → 15M users with 100% uptime maintained.'
+    },
+    metrics: [
+      { label: 'Users', value: '1M → 15M' },
+      { label: 'Page load', value: '60s → 2s' },
+      { label: 'Uptime', value: '100% through the growth' },
+      { label: 'Runtime', value: 'Node 5 → Node 12, ES5 → ES6' },
+      { label: 'Front end', value: 'Angular 1 → Vue rewrite' },
+      { label: 'Shipped', value: 'Apple Card integration + launch coordination' }
+    ],
+    stack: ['Node', 'JavaScript', 'Vue', 'Express', 'MongoDB', 'AWS'],
+    net: ['cfa'],
+    wave: 'burst'
+  },
+  {
+    id: 'cfa',
+    slot: '05',
+    org: 'Chick-fil-A',
+    window: '2020 → 2022',
+    role: 'Client channel 02 · project engineering lead',
+    face: ['CHICK-FIL-A', 'ENG LEAD · 3PD'],
+    headline: 'Under $1M a day to $5M a day, without dropping the orders.',
+    body: 'Project engineering lead for third-party delivery: DoorDash, UberEats and Grubhub patched into Chick-fil-A’s ordering platform. Covid turned a side channel into a main one, and the number that mattered was revenue per day — under one million to five million by 2022 — while every partner integration kept working. I shipped combo meals on UberEats, worth roughly ten percent more per order; worked with DoorDash’s engineers to put DoorDash checkout inside the Chick-fil-A iOS app; oversaw migrating the project’s infrastructure to AWS CloudFormation; and rebuilt logging, monitoring and alerting so we saw a partner outage before the partner called us.',
+    meter: {
+      label: 'Delivery revenue per day',
+      from: 1,
+      to: 5,
+      prefix: '$',
+      suffix: 'M',
+      decimals: 1,
+      note: 'Under $1M/day in 2020 to $5M/day by 2022, through Covid demand.'
+    },
+    metrics: [
+      { label: 'Revenue', value: '<$1M/day → $5M/day (2022)' },
+      { label: 'Partners', value: 'DoorDash · UberEats · Grubhub' },
+      { label: 'Combo meals', value: 'UberEats combos → ~10% higher revenue per order' },
+      { label: 'iOS', value: 'DoorDash checkout inside the Chick-fil-A app' },
+      { label: 'Infrastructure', value: 'Migrated the project to AWS CloudFormation' },
+      { label: 'Operations', value: 'Logging, monitoring, alerting rebuilt' }
+    ],
+    stack: ['Node', 'Go', 'TypeScript', 'AWS', 'CloudFormation', 'DynamoDB', 'Datadog'],
+    net: ['patch'],
+    wave: 'packet'
+  },
+  {
+    id: 'patch',
+    slot: '06',
+    org: 'Patch field',
+    window: 'Current',
+    role: 'Stack · chosen by access pattern',
+    face: ['PATCH FIELD', 'STACK'],
+    headline: 'The stack, as actually used in production.',
+    body: 'JavaScript, TypeScript, Go, Node, Express, Vue and React on the application side. MongoDB, DynamoDB and Postgres on the data side, picked by access pattern rather than by preference. AWS, Docker, Kubernetes and GitHub Actions to ship it; Datadog, Splunk and OpsGenie to watch it; Jira and Confluence because consulting is also a paperwork job.',
+    meter: {
+      label: 'Datastores run in production',
+      from: 0,
+      to: 3,
+      note: 'MongoDB, DynamoDB, Postgres — three different access-pattern bets.'
+    },
+    metrics: [
+      { label: 'Languages', value: 'JavaScript · TypeScript · Go' },
+      { label: 'Frameworks', value: 'Node · Express · Vue · React · Mongoose' },
+      { label: 'Data', value: 'MongoDB · DynamoDB · Postgres' },
+      { label: 'Ship', value: 'AWS · Docker · Kubernetes · GitHub Actions' },
+      { label: 'Watch', value: 'Datadog · Splunk · OpsGenie' }
+    ],
+    stack: [
+      'JavaScript',
+      'TypeScript',
+      'Go',
+      'Node',
+      'Vue',
+      'React',
+      'MongoDB',
+      'DynamoDB',
+      'Postgres',
+      'AWS',
+      'Kubernetes',
+      'Datadog'
+    ],
+    net: ['out'],
+    wave: 'pwm'
+  },
+  {
+    id: 'out',
+    slot: '07',
+    org: 'Output',
+    window: 'Open',
+    role: 'Output jack · contact',
+    face: ['OUTPUT', 'PATCH IN'],
+    headline: 'Patch in.',
+    body: 'Raleigh, North Carolina. Interested in high-traffic consumer platforms, integration work between systems that were never designed to talk to each other, and legacy modernisation that has to happen while the thing stays up.',
+    meter: {
+      label: 'Open channels',
+      from: 0,
+      to: 1,
+      note: 'devjbull@gmail.com — usually a same-day reply.'
+    },
+    metrics: [
+      { label: 'Location', value: 'Raleigh, North Carolina' },
+      { label: 'Email', value: 'devjbull@gmail.com' },
+      { label: 'Looking for', value: 'Platform, integrations, modernisation at scale' },
+      { label: 'Status', value: 'Open to conversations' }
+    ],
+    stack: [],
+    net: [],
+    links: [
+      { label: 'Email', href: 'mailto:devjbull@gmail.com' },
+      { label: 'LinkedIn', href: 'https://www.linkedin.com/in/bulldevon' },
+      { label: 'GitHub', href: 'https://github.com/DBULL7' },
+      { label: 'Run the system', href: '/systems' }
+    ],
+    wave: 'handshake'
+  }
+]
+
+export const unitsById = Object.fromEntries(
+  rackUnits.map((unit) => [unit.id, unit])
+) as Record<string, RackUnit>
+
+export const RACK_WIDTH = 12
+export const RACK_HEIGHT = 8
+export const UNIT_PITCH = RACK_HEIGHT / rackUnits.length
+
+export function unitCenterY(index: number) {
+  return RACK_HEIGHT / 2 - (index + 0.5) * UNIT_PITCH
+}
+
+export type Patch = { from: string; to: string; fromIndex: number; toIndex: number }
+
+export const patches: Patch[] = rackUnits.flatMap((unit, index) =>
+  unit.net
+    .map((targetId) => ({
+      from: unit.id,
+      to: targetId,
+      fromIndex: index,
+      toIndex: rackUnits.findIndex((entry) => entry.id === targetId)
+    }))
+    .filter((patch) => patch.toIndex >= 0)
+)
+
+export function formatMeter(meter: Meter, value: number) {
+  const decimals = meter.decimals ?? 0
+  return `${meter.prefix ?? ''}${value.toFixed(decimals)}${meter.suffix ?? ''}`
+}

--- a/app/career/career-experience.tsx
+++ b/app/career/career-experience.tsx
@@ -22,7 +22,10 @@ import styles from './career.module.css'
 
 const RackScene = dynamic(
   () => import('@/components/machine/rack-scene').then((mod) => mod.RackScene),
-  { ssr: false, loading: () => <div className={styles.sceneLoading} aria-hidden="true" /> }
+  {
+    ssr: false,
+    loading: () => <div className={styles.sceneLoading} aria-hidden="true" />
+  }
 )
 
 /* ---------------------------------------------------------------- waveform */
@@ -40,7 +43,10 @@ function stepPath(segments: Seg[]) {
         [end, y]
       ]
     })
-    .map(([x, y], index) => `${index === 0 ? 'M' : 'L'}${x.toFixed(2)} ${y.toFixed(2)}`)
+    .map(
+      ([x, y], index) =>
+        `${index === 0 ? 'M' : 'L'}${x.toFixed(2)} ${y.toFixed(2)}`
+    )
     .join(' ')
 }
 
@@ -82,7 +88,9 @@ function periodPath(wave: RackUnit['wave']) {
   }
   if (wave === 'packet') {
     const bits = [1, 0, 1, 1, 0, 1, 0, 0, 1, 1, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0]
-    return stepPath(bits.map((bit, index) => [index * 5, (index + 1) * 5, bit as 0 | 1]))
+    return stepPath(
+      bits.map((bit, index) => [index * 5, (index + 1) * 5, bit as 0 | 1])
+    )
   }
   if (wave === 'handshake') {
     return stepPath([
@@ -100,7 +108,8 @@ function periodPath(wave: RackUnit['wave']) {
   }
   return analogPath((t) => {
     const ripple = Math.sin(t * Math.PI * 14) * 1.1
-    const dip = t > 0.52 && t < 0.62 ? 12 * Math.sin(((t - 0.52) / 0.1) * Math.PI) : 0
+    const dip =
+      t > 0.52 && t < 0.62 ? 12 * Math.sin(((t - 0.52) / 0.1) * Math.PI) : 0
     return HI + 2 + ripple + dip
   })
 }
@@ -110,7 +119,10 @@ function useWaveform(wave: RackUnit['wave']) {
     const single = periodPath(wave)
     return [0, 100, 200]
       .map((offset) =>
-        single.replace(/([ML])([\d.-]+) /g, (_, cmd, x) => `${cmd}${Number(x) + offset} `)
+        single.replace(
+          /([ML])([\d.-]+) /g,
+          (_, cmd, x) => `${cmd}${Number(x) + offset} `
+        )
       )
       .join(' ')
   }, [wave])
@@ -166,20 +178,35 @@ function RackElevation({
         role="img"
         aria-label="Front elevation of the career rack: seven labelled units with meters."
       >
-        <rect x="0" y="0" width={PLAN_W} height={PLAN_H} className={styles.planFrame} />
+        <rect
+          x="0"
+          y="0"
+          width={PLAN_W}
+          height={PLAN_H}
+          className={styles.planFrame}
+        />
         {rackUnits.map((unit, index) => {
           const active = unit.id === activeId
           const y = planY(unitCenterY(index)) - unitPlanHeight / 2
-          const ratio =
-            unit.meter.to === 0 ? 0 : active ? 1 : 0.18
+          const ratio = unit.meter.to === 0 ? 0 : active ? 1 : 0.18
           return (
             <g
               key={unit.id}
               className={active ? styles.planUnitActive : styles.planUnit}
               onClick={() => onSelect(unit.id)}
             >
-              <rect x="26" y={y} width={PLAN_W - 52} height={unitPlanHeight} rx="4" />
-              <text x="58" y={y + unitPlanHeight / 2 + 9} className={styles.planSlot}>
+              <rect
+                x="26"
+                y={y}
+                width={PLAN_W - 52}
+                height={unitPlanHeight}
+                rx="4"
+              />
+              <text
+                x="58"
+                y={y + unitPlanHeight / 2 + 9}
+                className={styles.planSlot}
+              >
                 {unit.slot}
               </text>
               <text x="120" y={y + unitPlanHeight / 2 + 9}>
@@ -257,7 +284,9 @@ function Scope({
       <div className={styles.meterBlock} aria-live="polite">
         <p className={styles.meterLabel}>{meter.label}</p>
         <p className={styles.meterValue}>
-          <span className={styles.meterFrom}>{formatMeter(meter, meter.from)}</span>
+          <span className={styles.meterFrom}>
+            {formatMeter(meter, meter.from)}
+          </span>
           <span aria-hidden="true" className={styles.meterArrow}>
             →
           </span>
@@ -318,14 +347,29 @@ const specSheet = [
   { label: 'Title', value: 'Solutions Architect, Big Nerd Ranch' },
   { label: 'Since', value: 'July 2018' },
   { label: 'Location', value: 'Raleigh, North Carolina' },
-  { label: 'Client channels', value: 'Apple (2018–2020) · Chick-fil-A (2020–2022)' },
-  { label: 'Peak scale touched', value: '15M users · $5M/day in delivery revenue' },
+  {
+    label: 'Client channels',
+    value: 'Apple (2018–2020) · Chick-fil-A (2020–2022)'
+  },
+  {
+    label: 'Peak scale touched',
+    value: '15M users · $5M/day in delivery revenue'
+  },
   { label: 'Languages', value: 'JavaScript · TypeScript · Go' },
   { label: 'Frameworks', value: 'Node · Express · Vue · React · Mongoose' },
   { label: 'Data', value: 'MongoDB · DynamoDB · Postgres' },
-  { label: 'Tooling', value: 'AWS · Docker · Kubernetes · GitHub Actions · Git' },
-  { label: 'Operations', value: 'Datadog · Splunk · OpsGenie · Jira · Confluence' },
-  { label: 'Education', value: 'Turing School 2017 · B.A. Economics, Kansas 2015' }
+  {
+    label: 'Tooling',
+    value: 'AWS · Docker · Kubernetes · GitHub Actions · Git'
+  },
+  {
+    label: 'Operations',
+    value: 'Datadog · Splunk · OpsGenie · Jira · Confluence'
+  },
+  {
+    label: 'Education',
+    value: 'Turing School 2017 · B.A. Economics, Kansas 2015'
+  }
 ]
 
 export function CareerExperience() {
@@ -375,9 +419,10 @@ export function CareerExperience() {
             <p className={styles.lede}>
               Solutions Architect at Big Nerd Ranch since 2018. Backend lead on
               Apple’s chatbot while it went from 1M to 15M users, then
-              engineering lead on Chick-fil-A’s third-party delivery integrations
-              while daily revenue went from under $1M to $5M. Every unit in this
-              rack is a real engagement with a real number on the front panel.
+              engineering lead on Chick-fil-A’s third-party delivery
+              integrations while daily revenue went from under $1M to $5M. Every
+              unit in this rack is a real engagement with a real number on the
+              front panel.
             </p>
           </div>
           <ul className={styles.statusStack} aria-label="Rack status">
@@ -397,64 +442,74 @@ export function CareerExperience() {
         </header>
 
         <div className={styles.instrument}>
-          <div className={styles.viewport}>
-            <div className={styles.viewportInner}>
-              {live ? (
-                <RackScene
-                  theme={theme}
-                  activeId={activeId}
-                  onSelect={selectFromCanvas}
-                  onHover={setHoverId}
-                />
-              ) : (
-                <RackElevation activeId={activeId} onSelect={select} />
+          <div className={styles.column}>
+            <div className={styles.viewport}>
+              <div className={styles.viewportInner}>
+                {live ? (
+                  <RackScene
+                    theme={theme}
+                    activeId={activeId}
+                    onSelect={selectFromCanvas}
+                    onHover={setHoverId}
+                  />
+                ) : (
+                  <RackElevation activeId={activeId} onSelect={select} />
+                )}
+              </div>
+
+              <div className={styles.viewportRail}>
+                <span className={styles.railTag}>
+                  {live
+                    ? 'DRAG TO TILT · CLICK A UNIT'
+                    : 'STATIC RACK ELEVATION'}
+                </span>
+                <span className={styles.railTag}>
+                  {hoverId
+                    ? `HOVER ${unitsById[hoverId].slot} · ${unitsById[hoverId].org}`
+                    : `PULLED ${unit.slot} · ${unit.org}`}
+                </span>
+              </div>
+
+              {live && !touched && (
+                <p className={styles.coach} aria-hidden="true">
+                  <span>1 · drag to tilt the rack</span>
+                  <span>2 · click a unit to pull it out</span>
+                </p>
               )}
             </div>
 
-            <div className={styles.viewportRail}>
-              <span className={styles.railTag}>
-                {live ? 'DRAG TO TILT · CLICK A UNIT' : 'STATIC RACK ELEVATION'}
-              </span>
-              <span className={styles.railTag}>
-                {hoverId
-                  ? `HOVER ${unitsById[hoverId].slot} · ${unitsById[hoverId].org}`
-                  : `PULLED ${unit.slot} · ${unit.org}`}
-              </span>
-            </div>
-
-            {live && !touched && (
-              <p className={styles.coach} aria-hidden="true">
-                <span>1 · drag to tilt the rack</span>
-                <span>2 · click a unit to pull it out</span>
-              </p>
-            )}
-          </div>
-
-          <div className={styles.channels}>
-            <p className={styles.channelsLabel}>Rack units</p>
-            <div className={styles.channelGrid} role="group" aria-label="Rack units">
-              {rackUnits.map((item) => {
-                const isActive = item.id === activeId
-                return (
-                  <button
-                    key={item.id}
-                    type="button"
-                    className={isActive ? styles.channelActive : styles.channel}
-                    aria-pressed={isActive}
-                    onClick={() => select(item.id)}
-                    onMouseEnter={() => setHoverId(item.id)}
-                    onMouseLeave={() => setHoverId(null)}
-                    onFocus={() => setHoverId(item.id)}
-                    onBlur={() => setHoverId(null)}
-                  >
-                    <span className={styles.channelDesignator}>
-                      <i aria-hidden="true" />
-                      {item.slot} · {item.window}
-                    </span>
-                    <span className={styles.channelName}>{item.org}</span>
-                  </button>
-                )
-              })}
+            <div className={styles.channels}>
+              <p className={styles.channelsLabel}>Rack units</p>
+              <div
+                className={styles.channelGrid}
+                role="group"
+                aria-label="Rack units"
+              >
+                {rackUnits.map((item) => {
+                  const isActive = item.id === activeId
+                  return (
+                    <button
+                      key={item.id}
+                      type="button"
+                      className={
+                        isActive ? styles.channelActive : styles.channel
+                      }
+                      aria-pressed={isActive}
+                      onClick={() => select(item.id)}
+                      onMouseEnter={() => setHoverId(item.id)}
+                      onMouseLeave={() => setHoverId(null)}
+                      onFocus={() => setHoverId(item.id)}
+                      onBlur={() => setHoverId(null)}
+                    >
+                      <span className={styles.channelDesignator}>
+                        <i aria-hidden="true" />
+                        {item.slot} · {item.window}
+                      </span>
+                      <span className={styles.channelName}>{item.org}</span>
+                    </button>
+                  )
+                })}
+              </div>
             </div>
           </div>
 
@@ -525,7 +580,10 @@ export function CareerExperience() {
             ))}
           </dl>
           <div className={styles.specActions}>
-            <Link className={styles.primaryAction} href="mailto:devjbull@gmail.com">
+            <Link
+              className={styles.primaryAction}
+              href="mailto:devjbull@gmail.com"
+            >
               devjbull@gmail.com <span aria-hidden="true">↗</span>
             </Link>
             <Link

--- a/app/career/career-experience.tsx
+++ b/app/career/career-experience.tsx
@@ -2,308 +2,555 @@
 
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  RACK_HEIGHT,
+  RACK_WIDTH,
+  formatMeter,
+  patches,
+  rackUnits,
+  unitCenterY,
+  unitsById,
+  type RackUnit
+} from './career-data'
+import {
+  useMachineTheme,
+  usePrefersReducedMotion,
+  useWebglSupported
+} from '@/components/machine/machine-core'
 import styles from './career.module.css'
 
-const SpaceScene = dynamic(
-  () =>
-    import('@/components/space/space-scene').then(
-      (module) => module.SpaceScene
-    ),
-  {
-    ssr: false,
-    loading: () => <div className={styles.sceneFallback} aria-hidden="true" />
-  }
+const RackScene = dynamic(
+  () => import('@/components/machine/rack-scene').then((mod) => mod.RackScene),
+  { ssr: false, loading: () => <div className={styles.sceneLoading} aria-hidden="true" /> }
 )
 
-const chapters = {
-  origin: {
-    number: '00',
-    nav: 'Profile',
-    eyebrow: 'Current trajectory',
-    title: 'Devon Bull',
-    meta: 'Senior software engineer · Raleigh, NC',
-    text: 'Former tech entrepreneur turned engineer. I build dependable software, learn new domains quickly, and translate between product ambition and technical reality.'
-  },
-  consulting: {
-    number: '01',
-    nav: 'Consulting',
-    eyebrow: 'Primary arc',
-    title: 'Consulting engineer',
-    meta: 'One firm · many problem spaces',
-    text: 'Consulting taught me to arrive curious, earn context quickly, and create momentum inside established teams. The craft is making strong engineering fit the client and the operating environment.'
-  },
-  apple: {
-    number: '02',
-    nav: 'Apple',
-    eyebrow: 'Client system / 01',
-    title: 'Apple',
-    meta: 'Embedded engineering engagement',
-    text: 'Contributed to embedded work where hardware and software had to behave as a single, reliable product. The constraints rewarded precision, disciplined collaboration, and an eye for performance.'
-  },
-  chickfila: {
-    number: '03',
-    nav: 'Chick-fil-A',
-    eyebrow: 'Client system / 02',
-    title: 'Chick-fil-A',
-    meta: 'Embedded operational systems',
-    text: 'Worked on embedded solutions in an operational environment—connecting physical systems, production software, and the people who rely on both every day.'
-  },
-  platforms: {
-    number: '04',
-    nav: 'Range',
-    eyebrow: 'Extended range',
-    title: 'Full-stack platforms',
-    meta: 'Web · cloud · data · delivery',
-    text: 'Beyond embedded systems, I work across TypeScript, React, Node, Go, cloud services, databases, CI/CD, and observability. I like understanding the whole path from interface to infrastructure.'
-  },
-  leadership: {
-    number: '05',
-    nav: 'Leadership',
-    eyebrow: 'How I operate',
-    title: 'Calm, curious leadership',
-    meta: 'Teams · clients · systems',
-    text: 'I do my best work where the problem is ambiguous and the stakes are real: asking useful questions, bringing structure to uncertainty, and helping a team move without unnecessary drama.'
-  },
-  future: {
-    number: '06',
-    nav: 'Next',
-    eyebrow: 'Unresolved signal',
-    title: 'The next hard thing',
-    meta: 'Status · open to contact',
-    text: 'I am most interested in ambitious products, thoughtful teams, and work that expands what people believe software can do. If that sounds familiar, I would love to compare notes.'
-  }
-} as const
+/* ---------------------------------------------------------------- waveform */
 
-type ChapterId = keyof typeof chapters
+type Seg = [number, number, 0 | 1]
+const HI = 8
+const LO = 36
 
-const principles = [
-  {
-    number: '01',
-    title: 'Earn context',
-    text: 'Arrive curious, learn the operating environment, and understand the constraints before prescribing a solution.'
-  },
-  {
-    number: '02',
-    title: 'Connect the system',
-    text: 'Treat product goals, hardware, software, delivery, and the people using the system as one engineering problem.'
-  },
-  {
-    number: '03',
-    title: 'Create calm momentum',
-    text: 'Bring useful questions and enough structure to move an ambiguous problem forward without adding drama.'
+function stepPath(segments: Seg[]) {
+  return segments
+    .flatMap(([start, end, level]): [number, number][] => {
+      const y = level ? HI : LO
+      return [
+        [start, y],
+        [end, y]
+      ]
+    })
+    .map(([x, y], index) => `${index === 0 ? 'M' : 'L'}${x.toFixed(2)} ${y.toFixed(2)}`)
+    .join(' ')
+}
+
+function analogPath(sample: (t: number) => number, steps = 120) {
+  let path = ''
+  for (let index = 0; index <= steps; index += 1) {
+    const x = (index / steps) * 100
+    path += `${index === 0 ? 'M' : 'L'}${x.toFixed(2)} ${sample(index / steps).toFixed(2)}`
+    path += index === steps ? '' : ' '
   }
-] as const
+  return path
+}
+
+function periodPath(wave: RackUnit['wave']) {
+  if (wave === 'clock') {
+    const segments: Seg[] = []
+    for (let index = 0; index < 8; index += 1) {
+      segments.push([index * 12.5, index * 12.5 + 6.25, 1])
+      segments.push([index * 12.5 + 6.25, (index + 1) * 12.5, 0])
+    }
+    return stepPath(segments)
+  }
+  if (wave === 'pwm') {
+    const segments: Seg[] = []
+    for (let index = 0; index < 8; index += 1) {
+      segments.push([index * 12.5, index * 12.5 + 2.9, 1])
+      segments.push([index * 12.5 + 2.9, (index + 1) * 12.5, 0])
+    }
+    return stepPath(segments)
+  }
+  if (wave === 'burst') {
+    const segments: Seg[] = []
+    for (let index = 0; index < 9; index += 1) {
+      segments.push([index * 5, index * 5 + 2.4, 1])
+      segments.push([index * 5 + 2.4, (index + 1) * 5, 0])
+    }
+    segments.push([45, 100, 1])
+    return stepPath(segments)
+  }
+  if (wave === 'packet') {
+    const bits = [1, 0, 1, 1, 0, 1, 0, 0, 1, 1, 1, 0, 1, 0, 1, 1, 0, 0, 1, 0]
+    return stepPath(bits.map((bit, index) => [index * 5, (index + 1) * 5, bit as 0 | 1]))
+  }
+  if (wave === 'handshake') {
+    return stepPath([
+      [0, 8, 0],
+      [8, 13, 1],
+      [13, 34, 0],
+      [34, 39, 1],
+      [39, 46, 0],
+      [46, 51, 1],
+      [51, 100, 0]
+    ])
+  }
+  if (wave === 'ramp') {
+    return analogPath((t) => LO - ((t * 2) % 1) * (LO - HI))
+  }
+  return analogPath((t) => {
+    const ripple = Math.sin(t * Math.PI * 14) * 1.1
+    const dip = t > 0.52 && t < 0.62 ? 12 * Math.sin(((t - 0.52) / 0.1) * Math.PI) : 0
+    return HI + 2 + ripple + dip
+  })
+}
+
+function useWaveform(wave: RackUnit['wave']) {
+  return useMemo(() => {
+    const single = periodPath(wave)
+    return [0, 100, 200]
+      .map((offset) =>
+        single.replace(/([ML])([\d.-]+) /g, (_, cmd, x) => `${cmd}${Number(x) + offset} `)
+      )
+      .join(' ')
+  }, [wave])
+}
+
+/* ------------------------------------------------------------ meter readout */
+
+function useCountUp(unit: RackUnit, animate: boolean) {
+  const [value, setValue] = useState(unit.meter.to)
+
+  useEffect(() => {
+    if (!animate) {
+      setValue(unit.meter.to)
+      return
+    }
+    const { from, to } = unit.meter
+    const duration = 1200
+    const start = performance.now()
+    let raf = 0
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - start) / duration)
+      const eased = 1 - Math.pow(1 - t, 3)
+      setValue(from + (to - from) * eased)
+      if (t < 1) raf = requestAnimationFrame(tick)
+    }
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
+  }, [unit, animate])
+
+  return value
+}
+
+/* ------------------------------------------------------- rack elevation svg */
+
+const PLAN_W = 1200
+const PLAN_H = 800
+const planX = (x: number) => ((x + RACK_WIDTH / 2) / RACK_WIDTH) * PLAN_W
+const planY = (y: number) => ((RACK_HEIGHT / 2 - y) / RACK_HEIGHT) * PLAN_H
+const unitPlanHeight = (PLAN_H / rackUnits.length) * 0.86
+
+function RackElevation({
+  activeId,
+  onSelect
+}: {
+  activeId: string
+  onSelect: (id: string) => void
+}) {
+  return (
+    <div className={styles.planWrap}>
+      <svg
+        className={styles.plan}
+        viewBox={`0 0 ${PLAN_W} ${PLAN_H}`}
+        role="img"
+        aria-label="Front elevation of the career rack: seven labelled units with meters."
+      >
+        <rect x="0" y="0" width={PLAN_W} height={PLAN_H} className={styles.planFrame} />
+        {rackUnits.map((unit, index) => {
+          const active = unit.id === activeId
+          const y = planY(unitCenterY(index)) - unitPlanHeight / 2
+          const ratio =
+            unit.meter.to === 0 ? 0 : active ? 1 : 0.18
+          return (
+            <g
+              key={unit.id}
+              className={active ? styles.planUnitActive : styles.planUnit}
+              onClick={() => onSelect(unit.id)}
+            >
+              <rect x="26" y={y} width={PLAN_W - 52} height={unitPlanHeight} rx="4" />
+              <text x="58" y={y + unitPlanHeight / 2 + 9} className={styles.planSlot}>
+                {unit.slot}
+              </text>
+              <text x="120" y={y + unitPlanHeight / 2 + 9}>
+                {unit.face[0]}
+              </text>
+              <text
+                x="430"
+                y={y + unitPlanHeight / 2 + 8}
+                className={styles.planMeta}
+              >
+                {unit.window.toUpperCase()}
+              </text>
+              <rect
+                x="700"
+                y={y + unitPlanHeight * 0.3}
+                width="440"
+                height={unitPlanHeight * 0.4}
+                className={styles.planMeterBg}
+              />
+              <rect
+                x="704"
+                y={y + unitPlanHeight * 0.3 + 4}
+                width={432 * ratio}
+                height={unitPlanHeight * 0.4 - 8}
+                className={styles.planMeterFill}
+              />
+            </g>
+          )
+        })}
+      </svg>
+    </div>
+  )
+}
+
+/* ------------------------------------------------------------------- scope */
+
+function Scope({
+  unit,
+  live,
+  animate
+}: {
+  unit: RackUnit
+  live: boolean
+  animate: boolean
+}) {
+  const path = useWaveform(unit.wave)
+  const value = useCountUp(unit, animate)
+  const meter = unit.meter
+
+  return (
+    <div className={styles.scope}>
+      <div className={styles.scopeHead}>
+        <span className={styles.scopeChannel}>
+          <i className={styles.ledSignal} aria-hidden="true" />
+          SLOT {unit.slot}
+        </span>
+        <span>{unit.window.toUpperCase()}</span>
+        <span className={styles.scopeHeadRight}>{live ? 'LIVE' : 'HELD'}</span>
+      </div>
+
+      <div className={styles.screen}>
+        <svg
+          className={styles.trace}
+          viewBox="0 0 100 44"
+          preserveAspectRatio="none"
+          aria-hidden="true"
+        >
+          <path d={path} vectorEffect="non-scaling-stroke" />
+        </svg>
+        <span className={styles.screenTagLeft}>{unit.org}</span>
+        <span className={styles.screenTagRight}>{meter.label}</span>
+        <span className={styles.screenScale}>2 V/div · 5 ms/div · TRIG ↑</span>
+      </div>
+
+      <div className={styles.meterBlock} aria-live="polite">
+        <p className={styles.meterLabel}>{meter.label}</p>
+        <p className={styles.meterValue}>
+          <span className={styles.meterFrom}>{formatMeter(meter, meter.from)}</span>
+          <span aria-hidden="true" className={styles.meterArrow}>
+            →
+          </span>
+          <strong>{formatMeter(meter, value)}</strong>
+        </p>
+        <p className={styles.meterNote}>{meter.note}</p>
+      </div>
+
+      <div className={styles.readout}>
+        <p className={styles.readoutRole}>{unit.role}</p>
+        <h2 className={styles.readoutTitle}>{unit.org}</h2>
+        <p className={styles.readoutHead}>{unit.headline}</p>
+        <p className={styles.readoutBody}>{unit.body}</p>
+
+        <dl className={styles.measured}>
+          {unit.metrics.map((row) => (
+            <div key={row.label}>
+              <dt>{row.label}</dt>
+              <dd>{row.value}</dd>
+            </div>
+          ))}
+        </dl>
+
+        {unit.stack.length > 0 && (
+          <ul className={styles.chips} aria-label={`${unit.org} stack`}>
+            {unit.stack.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        )}
+
+        {unit.links && (
+          <div className={styles.readoutLinks}>
+            {unit.links.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={styles.linkButton}
+                {...(link.href.startsWith('http')
+                  ? { target: '_blank', rel: 'noreferrer' }
+                  : {})}
+              >
+                {link.label}
+                <span aria-hidden="true">↗</span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/* -------------------------------------------------------------------- page */
+
+const specSheet = [
+  { label: 'Name', value: 'Devon Bull' },
+  { label: 'Title', value: 'Solutions Architect, Big Nerd Ranch' },
+  { label: 'Since', value: 'July 2018' },
+  { label: 'Location', value: 'Raleigh, North Carolina' },
+  { label: 'Client channels', value: 'Apple (2018–2020) · Chick-fil-A (2020–2022)' },
+  { label: 'Peak scale touched', value: '15M users · $5M/day in delivery revenue' },
+  { label: 'Languages', value: 'JavaScript · TypeScript · Go' },
+  { label: 'Frameworks', value: 'Node · Express · Vue · React · Mongoose' },
+  { label: 'Data', value: 'MongoDB · DynamoDB · Postgres' },
+  { label: 'Tooling', value: 'AWS · Docker · Kubernetes · GitHub Actions · Git' },
+  { label: 'Operations', value: 'Datadog · Splunk · OpsGenie · Jira · Confluence' },
+  { label: 'Education', value: 'Turing School 2017 · B.A. Economics, Kansas 2015' }
+]
 
 export function CareerExperience() {
-  const [active, setActive] = useState<ChapterId>('origin')
+  const theme = useMachineTheme()
+  const reduced = usePrefersReducedMotion()
+  const webgl = useWebglSupported()
+  const [activeId, setActiveId] = useState('apple')
+  const [hoverId, setHoverId] = useState<string | null>(null)
+  const [touched, setTouched] = useState(false)
+  const scopeRef = useRef<HTMLDivElement>(null)
+
+  const unit = unitsById[activeId]
+  const live = webgl === true && !reduced
+
   const select = useCallback((id: string) => {
-    if (id in chapters) setActive(id as ChapterId)
+    if (!unitsById[id]) return
+    setActiveId(id)
+    setTouched(true)
   }, [])
-  const chapter = chapters[active]
+
+  const selectFromCanvas = useCallback(
+    (id: string) => {
+      select(id)
+      if (window.matchMedia('(max-width: 1080px)').matches) {
+        scopeRef.current?.scrollIntoView({
+          behavior: reduced ? 'auto' : 'smooth',
+          block: 'start'
+        })
+      }
+    },
+    [select, reduced]
+  )
+
+  useEffect(() => {
+    if (!live) return
+    const timer = window.setTimeout(() => setTouched(true), 15000)
+    return () => window.clearTimeout(timer)
+  }, [live])
 
   return (
     <main className={styles.page}>
-      <section className={styles.hero} aria-labelledby="career-title">
-        <SpaceScene mode="career" onNodeSelect={select} />
-        <div className={styles.heroShade} aria-hidden="true" />
-
-        <div className={styles.heroHeading}>
-          <p className={styles.eyebrow}>Career constellation · 002</p>
-          <h1 id="career-title">One career. Many systems.</h1>
-          <p>
-            A former tech entrepreneur turned senior software engineer, working
-            from embedded systems to cloud platforms—and translating between
-            ambitious products and the realities that make them dependable.
-          </p>
-          <a className={styles.readLink} href="#career-narrative">
-            Read the complete narrative <span aria-hidden="true">↓</span>
-          </a>
-        </div>
-
-        <div className={styles.explorer}>
-          <nav className={styles.chapterNav} aria-label="Career chapters">
-            {Object.entries(chapters).map(([id, item]) => (
-              <button
-                key={id}
-                type="button"
-                className={
-                  active === id
-                    ? styles.chapterButtonActive
-                    : styles.chapterButton
-                }
-                onClick={() => setActive(id as ChapterId)}
-                aria-pressed={active === id}
-              >
-                <span>{item.number}</span>
-                {item.nav}
-              </button>
-            ))}
-          </nav>
-
-          <article
-            className={styles.activeChapter}
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            <p className={styles.panelEyebrow}>{chapter.eyebrow}</p>
-            <div className={styles.chapterTitleRow}>
-              <span>{chapter.number}</span>
-              <h2>{chapter.title}</h2>
-            </div>
-            <p className={styles.chapterMeta}>{chapter.meta}</p>
-            <p className={styles.chapterText}>{chapter.text}</p>
-          </article>
-        </div>
-
-        <p className={styles.visualNote}>
-          Spatial map is optional. Every chapter appears in plain text below.
-        </p>
-      </section>
-
-      <section
-        id="career-narrative"
-        className={styles.narrative}
-        aria-labelledby="narrative-title"
-      >
-        <div className={styles.sectionIntro}>
+      <section className={styles.bench} aria-labelledby="career-title">
+        <header className={styles.benchHead}>
           <div>
-            <p className={styles.eyebrow}>Career · in plain text</p>
-            <h2 id="narrative-title">The legible version.</h2>
+            <p className={styles.eyebrow}>Rack 01 · career · devon bull</p>
+            <h1 id="career-title">Pull the unit. Read the meter.</h1>
+            <p className={styles.lede}>
+              Solutions Architect at Big Nerd Ranch since 2018. Backend lead on
+              Apple’s chatbot while it went from 1M to 15M users, then
+              engineering lead on Chick-fil-A’s third-party delivery integrations
+              while daily revenue went from under $1M to $5M. Every unit in this
+              rack is a real engagement with a real number on the front panel.
+            </p>
           </div>
-          <p>
-            I have worked for one contracting firm across different client and
-            technical contexts. That path built range without losing the
-            through-line: understand the whole system, then make it more
-            dependable.
-          </p>
-        </div>
+          <ul className={styles.statusStack} aria-label="Rack status">
+            <li>
+              <i className={styles.ledOk} aria-hidden="true" />
+              PWR OK
+            </li>
+            <li>
+              <i className={styles.ledSignal} aria-hidden="true" />
+              {live ? 'RACK LIVE' : 'ELEVATION'}
+            </li>
+            <li>
+              <i className={styles.ledAmber} aria-hidden="true" />
+              {rackUnits.length} UNITS
+            </li>
+          </ul>
+        </header>
 
-        <div className={styles.evidenceGrid}>
-          <article
-            className={`${styles.evidenceCard} ${styles.evidenceCardPrimary}`}
-          >
-            <div className={styles.cardTopline}>
-              <span>Foundation</span>
-              <span>Former tech entrepreneur</span>
+        <div className={styles.instrument}>
+          <div className={styles.viewport}>
+            <div className={styles.viewportInner}>
+              {live ? (
+                <RackScene
+                  theme={theme}
+                  activeId={activeId}
+                  onSelect={selectFromCanvas}
+                  onHover={setHoverId}
+                />
+              ) : (
+                <RackElevation activeId={activeId} onSelect={select} />
+              )}
             </div>
-            <div>
-              <h3>Product ambition with engineering discipline.</h3>
-              <p>
-                Entrepreneurship shaped how I frame problems and weigh
-                tradeoffs. Engineering became the way I turn that product
-                perspective into reliable systems a team can operate and
-                improve.
+
+            <div className={styles.viewportRail}>
+              <span className={styles.railTag}>
+                {live ? 'DRAG TO TILT · CLICK A UNIT' : 'STATIC RACK ELEVATION'}
+              </span>
+              <span className={styles.railTag}>
+                {hoverId
+                  ? `HOVER ${unitsById[hoverId].slot} · ${unitsById[hoverId].org}`
+                  : `PULLED ${unit.slot} · ${unit.org}`}
+              </span>
+            </div>
+
+            {live && !touched && (
+              <p className={styles.coach} aria-hidden="true">
+                <span>1 · drag to tilt the rack</span>
+                <span>2 · click a unit to pull it out</span>
               </p>
-            </div>
-          </article>
+            )}
+          </div>
 
-          <article className={styles.evidenceCard}>
-            <div className={styles.cardTopline}>
-              <span>Client engagement</span>
-              <span>Embedded</span>
+          <div className={styles.channels}>
+            <p className={styles.channelsLabel}>Rack units</p>
+            <div className={styles.channelGrid} role="group" aria-label="Rack units">
+              {rackUnits.map((item) => {
+                const isActive = item.id === activeId
+                return (
+                  <button
+                    key={item.id}
+                    type="button"
+                    className={isActive ? styles.channelActive : styles.channel}
+                    aria-pressed={isActive}
+                    onClick={() => select(item.id)}
+                    onMouseEnter={() => setHoverId(item.id)}
+                    onMouseLeave={() => setHoverId(null)}
+                    onFocus={() => setHoverId(item.id)}
+                    onBlur={() => setHoverId(null)}
+                  >
+                    <span className={styles.channelDesignator}>
+                      <i aria-hidden="true" />
+                      {item.slot} · {item.window}
+                    </span>
+                    <span className={styles.channelName}>{item.org}</span>
+                  </button>
+                )
+              })}
             </div>
-            <div>
-              <h3>Apple</h3>
-              <p>{chapters.apple.text}</p>
-            </div>
-          </article>
+          </div>
 
-          <article className={styles.evidenceCard}>
-            <div className={styles.cardTopline}>
-              <span>Client engagement</span>
-              <span>Embedded operations</span>
-            </div>
-            <div>
-              <h3>Chick-fil-A</h3>
-              <p>{chapters.chickfila.text}</p>
-            </div>
-          </article>
+          <div className={styles.scopeColumn} ref={scopeRef}>
+            <Scope unit={unit} live={live} animate={!reduced} />
+          </div>
         </div>
       </section>
 
-      <section className={styles.range} aria-labelledby="range-title">
-        <div className={styles.rangeHeading}>
-          <div>
-            <p className={styles.eyebrow}>Engineering range</p>
-            <h2 id="range-title">
-              From device constraints to delivery systems.
-            </h2>
-          </div>
+      <section className={styles.bom} aria-labelledby="log-title">
+        <div className={styles.sectionHead}>
+          <p className={styles.eyebrow}>Service log</p>
+          <h2 id="log-title">The whole rack in plain text.</h2>
           <p>
-            Embedded work is a defining part of the story, not the boundary. I
-            also work across application, platform, cloud, data, delivery, and
-            observability concerns.
+            No canvas, no drag, no meters — the same seven units written out for
+            anyone who would rather read than click, including screen readers,
+            printers and hiring managers in a hurry.
           </p>
         </div>
-        <div
-          className={styles.rangeBands}
-          aria-label="Areas of engineering experience"
-        >
-          <div>
-            <span>01</span>
-            <strong>Embedded systems</strong>
-            <small>Hardware + software</small>
-          </div>
-          <div>
-            <span>02</span>
-            <strong>Product applications</strong>
-            <small>TypeScript + React + Node</small>
-          </div>
-          <div>
-            <span>03</span>
-            <strong>Services & data</strong>
-            <small>Go + databases</small>
-          </div>
-          <div>
-            <span>04</span>
-            <strong>Platforms</strong>
-            <small>Cloud + CI/CD + observability</small>
-          </div>
-        </div>
-      </section>
 
-      <section className={styles.principles} aria-labelledby="principles-title">
-        <div className={styles.principlesHeading}>
-          <p className={styles.eyebrow}>Operating principles</p>
-          <h2 id="principles-title">
-            How I work when the answer is not obvious.
-          </h2>
-        </div>
-        <div className={styles.principleGrid}>
-          {principles.map((principle) => (
-            <article key={principle.number}>
-              <span>{principle.number}</span>
-              <h3>{principle.title}</h3>
-              <p>{principle.text}</p>
-            </article>
+        <ol className={styles.bomList}>
+          {rackUnits.map((item) => (
+            <li key={item.id} id={`unit-${item.id}`}>
+              <article className={styles.bomRow}>
+                <div className={styles.bomIdent}>
+                  <span className={styles.bomDesignator}>SLOT {item.slot}</span>
+                  <h3>{item.org}</h3>
+                  <p className={styles.bomRole}>{item.role}</p>
+                  <p className={styles.bomNet}>{item.window}</p>
+                </div>
+                <div className={styles.bomText}>
+                  <p className={styles.bomHead}>{item.headline}</p>
+                  <p>{item.body}</p>
+                  <dl className={styles.bomMetrics}>
+                    {item.metrics.map((row) => (
+                      <div key={row.label}>
+                        <dt>{row.label}</dt>
+                        <dd>{row.value}</dd>
+                      </div>
+                    ))}
+                  </dl>
+                  {item.stack.length > 0 && (
+                    <ul className={styles.chips}>
+                      {item.stack.map((entry) => (
+                        <li key={entry}>{entry}</li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              </article>
+            </li>
           ))}
-        </div>
+        </ol>
       </section>
 
-      <section className={styles.nextSignal} aria-labelledby="next-title">
-        <div>
-          <p className={styles.eyebrow}>Next signal</p>
-          <h2 id="next-title">
-            Ambitious products. Thoughtful teams. Hard systems.
-          </h2>
-        </div>
-        <div className={styles.nextCopy}>
-          <p>{chapters.future.text}</p>
-          <div className={styles.nextLinks}>
-            <Link href="/systems">
-              Explore technical range <span aria-hidden="true">→</span>
+      <section className={styles.spec} aria-labelledby="spec-title">
+        <div className={styles.specInner}>
+          <div className={styles.sectionHead}>
+            <p className={styles.eyebrow}>Datasheet</p>
+            <h2 id="spec-title">Absolute maximum ratings.</h2>
+          </div>
+          <dl className={styles.specGrid}>
+            {specSheet.map((row) => (
+              <div key={row.label}>
+                <dt>{row.label}</dt>
+                <dd>{row.value}</dd>
+              </div>
+            ))}
+          </dl>
+          <div className={styles.specActions}>
+            <Link className={styles.primaryAction} href="mailto:devjbull@gmail.com">
+              devjbull@gmail.com <span aria-hidden="true">↗</span>
             </Link>
-            <a
+            <Link
+              className={styles.secondaryAction}
               href="https://www.linkedin.com/in/bulldevon"
               target="_blank"
               rel="noreferrer"
             >
-              Connect on LinkedIn{' '}
-              <span className="sr-only">(opens in a new tab)</span>
-              <span aria-hidden="true">↗</span>
-            </a>
+              LinkedIn <span aria-hidden="true">↗</span>
+            </Link>
+            <Link
+              className={styles.secondaryAction}
+              href="https://github.com/DBULL7"
+              target="_blank"
+              rel="noreferrer"
+            >
+              GitHub <span aria-hidden="true">↗</span>
+            </Link>
+            <Link className={styles.secondaryAction} href="/systems">
+              Run the system <span aria-hidden="true">→</span>
+            </Link>
           </div>
+          <p className={styles.patchNote}>
+            {patches.length} patch cables · {rackUnits.length} units · one firm
+          </p>
         </div>
       </section>
     </main>

--- a/app/career/career-experience.tsx
+++ b/app/career/career-experience.tsx
@@ -344,19 +344,21 @@ function Scope({
 
 const specSheet = [
   { label: 'Name', value: 'Devon Bull' },
-  { label: 'Title', value: 'Solutions Architect, Big Nerd Ranch' },
-  { label: 'Since', value: 'July 2018' },
-  { label: 'Location', value: 'Raleigh, North Carolina' },
+  { label: 'Target role', value: 'Product engineer / senior full-stack' },
   {
-    label: 'Client channels',
-    value: 'Apple (2018–2020) · Chick-fil-A (2020–2022)'
+    label: 'Employer',
+    value: 'Stellar Elements (formerly Big Nerd Ranch), an Amdocs company'
   },
+  { label: 'Tenure', value: 'July 2018 → present · one firm, 7+ years' },
+  { label: 'Location', value: 'Raleigh, North Carolina' },
+  { label: 'Apple', value: '2018 → present across three eras' },
+  { label: 'Chick-fil-A', value: '2020 → 2022, third-party delivery lead' },
   {
     label: 'Peak scale touched',
     value: '15M users · $5M/day in delivery revenue'
   },
-  { label: 'Languages', value: 'JavaScript · TypeScript · Go' },
-  { label: 'Frameworks', value: 'Node · Express · Vue · React · Mongoose' },
+  { label: 'Front end', value: 'React · TypeScript · Vue · Redux' },
+  { label: 'Back end', value: 'Node · Express · Go · Mongoose' },
   { label: 'Data', value: 'MongoDB · DynamoDB · Postgres' },
   {
     label: 'Tooling',
@@ -369,19 +371,20 @@ const specSheet = [
   {
     label: 'Education',
     value: 'Turing School 2017 · B.A. Economics, Kansas 2015'
-  }
+  },
+  { label: 'Email', value: 'devjbull@gmail.com' }
 ]
 
 export function CareerExperience() {
   const theme = useMachineTheme()
   const reduced = usePrefersReducedMotion()
   const webgl = useWebglSupported()
-  const [activeId, setActiveId] = useState('apple')
+  const [activeId, setActiveId] = useState('apple1')
   const [hoverId, setHoverId] = useState<string | null>(null)
   const [touched, setTouched] = useState(false)
   const scopeRef = useRef<HTMLDivElement>(null)
 
-  const unit = unitsById[activeId]
+  const unit = unitsById[activeId] ?? rackUnits[0]
   const live = webgl === true && !reduced
 
   const select = useCallback((id: string) => {
@@ -417,12 +420,15 @@ export function CareerExperience() {
             <p className={styles.eyebrow}>Rack 01 · career · devon bull</p>
             <h1 id="career-title">Pull the unit. Read the meter.</h1>
             <p className={styles.lede}>
-              Solutions Architect at Big Nerd Ranch since 2018. Backend lead on
-              Apple’s chatbot while it went from 1M to 15M users, then
-              engineering lead on Chick-fil-A’s third-party delivery
-              integrations while daily revenue went from under $1M to $5M. Every
-              unit in this rack is a real engagement with a real number on the
-              front panel.
+              Product engineer in Raleigh, NC. Seven years at one firm — Stellar
+              Elements, formerly Big Nerd Ranch, now an Amdocs company — and
+              seven years inside Apple across three eras: backend lead on the
+              chatbot as it went 1M → 15M users, two years as the sole engineer
+              on an internal cloud UI, and now Apple’s internal cloud site as it
+              becomes a full developer portal. In between, engineering lead on
+              Chick-fil-A’s delivery integrations while daily revenue went from
+              under $1M to $5M. Every unit in this rack is a real engagement
+              with a real number on the front panel.
             </p>
           </div>
           <ul className={styles.statusStack} aria-label="Rack status">

--- a/app/career/career.module.css
+++ b/app/career/career.module.css
@@ -205,6 +205,7 @@
     'channels scope';
   grid-template-columns: minmax(0, 1fr) minmax(21rem, 27rem);
   grid-template-rows: auto auto;
+  align-items: start;
   gap: clamp(0.9rem, 1.6vw, 1.4rem);
 }
 

--- a/app/career/career.module.css
+++ b/app/career/career.module.css
@@ -18,14 +18,17 @@
   --etch: rgba(180, 230, 220, 0.05);
   color: var(--text);
   background-color: var(--chassis);
-  background-image:
-    repeating-linear-gradient(
-      115deg,
-      var(--etch) 0 1px,
-      transparent 1px 6px
-    );
+  background-image: repeating-linear-gradient(
+    115deg,
+    var(--etch) 0 1px,
+    transparent 1px 6px
+  );
   font-family:
-    ui-sans-serif, system-ui, -apple-system, 'Helvetica Neue', sans-serif;
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    'Helvetica Neue',
+    sans-serif;
 }
 
 :global(html.light) .page {
@@ -50,23 +53,23 @@
 
 @media (prefers-color-scheme: light) {
   :global(html:not(.dark)) .page {
-  --chassis: #eee7db;
-  --panel: #f6f1e7;
-  --panel-2: #e8e0d1;
-  --line: rgba(20, 45, 40, 0.2);
-  --line-strong: rgba(20, 45, 40, 0.42);
-  --text: #16211f;
-  --muted: rgba(22, 33, 31, 0.68);
-  --signal: #0d7a63;
-  --amber: #9a5a15;
-  --fault: #b1372a;
-  --paper: #fbf8f1;
-  --paper-ink: #14201e;
-  --screen: #061210;
-  --screen-ink: #cffbec;
-  --screen-signal: #86f0d2;
-  --shadow: 0 18px 34px rgba(35, 45, 40, 0.16);
-  --etch: rgba(20, 45, 40, 0.06);
+    --chassis: #eee7db;
+    --panel: #f6f1e7;
+    --panel-2: #e8e0d1;
+    --line: rgba(20, 45, 40, 0.2);
+    --line-strong: rgba(20, 45, 40, 0.42);
+    --text: #16211f;
+    --muted: rgba(22, 33, 31, 0.68);
+    --signal: #0d7a63;
+    --amber: #9a5a15;
+    --fault: #b1372a;
+    --paper: #fbf8f1;
+    --paper-ink: #14201e;
+    --screen: #061210;
+    --screen-ink: #cffbec;
+    --screen-signal: #86f0d2;
+    --shadow: 0 18px 34px rgba(35, 45, 40, 0.16);
+    --etch: rgba(20, 45, 40, 0.06);
   }
 }
 
@@ -200,32 +203,47 @@
 .instrument {
   display: grid;
   margin-top: clamp(1.5rem, 3vw, 2.25rem);
-  grid-template-areas:
-    'viewport scope'
-    'channels scope';
   grid-template-columns: minmax(0, 1fr) minmax(21rem, 27rem);
-  grid-template-rows: auto auto;
   align-items: start;
+  gap: clamp(0.9rem, 1.6vw, 1.4rem);
+}
+
+.column {
+  display: grid;
+  min-width: 0;
   gap: clamp(0.9rem, 1.6vw, 1.4rem);
 }
 
 .viewport {
   position: relative;
-  grid-area: viewport;
   padding: 0.75rem;
   border: 1px solid var(--line-strong);
   border-radius: 4px;
   background:
-    radial-gradient(circle at 0.95rem 0.95rem, var(--line-strong) 0 2.5px, transparent 3px),
-    radial-gradient(circle at calc(100% - 0.95rem) 0.95rem, var(--line-strong) 0 2.5px, transparent 3px),
-    radial-gradient(circle at 0.95rem calc(100% - 0.95rem), var(--line-strong) 0 2.5px, transparent 3px),
+    radial-gradient(
+      circle at 0.95rem 0.95rem,
+      var(--line-strong) 0 2.5px,
+      transparent 3px
+    ),
+    radial-gradient(
+      circle at calc(100% - 0.95rem) 0.95rem,
+      var(--line-strong) 0 2.5px,
+      transparent 3px
+    ),
+    radial-gradient(
+      circle at 0.95rem calc(100% - 0.95rem),
+      var(--line-strong) 0 2.5px,
+      transparent 3px
+    ),
     radial-gradient(
       circle at calc(100% - 0.95rem) calc(100% - 0.95rem),
       var(--line-strong) 0 2.5px,
       transparent 3px
     ),
     linear-gradient(180deg, var(--panel-2), var(--panel));
-  box-shadow: var(--shadow), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  box-shadow:
+    var(--shadow),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
 .viewportInner {
@@ -241,7 +259,11 @@
   width: 100%;
   height: 100%;
   background:
-    radial-gradient(circle at 50% 55%, rgba(134, 240, 210, 0.08), transparent 60%),
+    radial-gradient(
+      circle at 50% 55%,
+      rgba(134, 240, 210, 0.08),
+      transparent 60%
+    ),
     var(--chassis);
 }
 
@@ -301,7 +323,6 @@
 /* ---------------------------------------------------------------- channels */
 
 .channels {
-  grid-area: channels;
   padding: 0.85rem 0.9rem 1rem;
   border: 1px solid var(--line);
   border-radius: 4px;
@@ -400,7 +421,6 @@
 /* ------------------------------------------------------------------ scope */
 
 .scopeColumn {
-  grid-area: scope;
   scroll-margin-top: 5rem;
 }
 
@@ -411,7 +431,9 @@
   border: 1px solid var(--line-strong);
   border-radius: 4px;
   background: linear-gradient(180deg, var(--panel-2), var(--panel));
-  box-shadow: var(--shadow), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  box-shadow:
+    var(--shadow),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
 .scopeHead {
@@ -454,7 +476,9 @@
     linear-gradient(rgba(134, 240, 210, 0.11) 1px, transparent 1px),
     linear-gradient(90deg, rgba(134, 240, 210, 0.11) 1px, transparent 1px);
   background-position: center center;
-  background-size: 12.5% 20%, 12.5% 20%;
+  background-size:
+    12.5% 20%,
+    12.5% 20%;
   box-shadow: inset 0 0 2.5rem rgba(0, 0, 0, 0.75);
 }
 
@@ -764,7 +788,8 @@
 /* ------------------------------------------------------------------- spec */
 
 .spec {
-  padding: clamp(3rem, 6vw, 5.5rem) clamp(1rem, 4vw, 3rem) clamp(4rem, 8vw, 7rem);
+  padding: clamp(3rem, 6vw, 5.5rem) clamp(1rem, 4vw, 3rem)
+    clamp(4rem, 8vw, 7rem);
   background:
     repeating-linear-gradient(115deg, var(--etch) 0 1px, transparent 1px 6px),
     var(--chassis);
@@ -924,7 +949,6 @@
   fill: var(--signal);
 }
 
-
 /* ------------------------------------------------------------- meter block */
 
 .meterBlock {
@@ -1024,10 +1048,6 @@
 
 @media (max-width: 1080px) {
   .instrument {
-    grid-template-areas:
-      'viewport'
-      'channels'
-      'scope';
     grid-template-columns: minmax(0, 1fr);
   }
 

--- a/app/career/career.module.css
+++ b/app/career/career.module.css
@@ -1,405 +1,607 @@
 .page {
-  color: #dcebe6;
-  background: #03070a;
+  --chassis: #070c0e;
+  --panel: #0c1416;
+  --panel-2: #111c1e;
+  --line: rgba(160, 210, 200, 0.16);
+  --line-strong: rgba(160, 210, 200, 0.36);
+  --text: #dfeae7;
+  --muted: rgba(223, 234, 231, 0.62);
+  --signal: #86f0d2;
+  --amber: #f0b45a;
+  --fault: #ff6b57;
+  --paper: #efe9dc;
+  --paper-ink: #14201e;
+  --screen: #050d0c;
+  --screen-ink: #cffbec;
+  --screen-signal: #86f0d2;
+  --shadow: 0 24px 48px rgba(0, 0, 0, 0.5);
+  --etch: rgba(180, 230, 220, 0.05);
+  color: var(--text);
+  background-color: var(--chassis);
+  background-image:
+    repeating-linear-gradient(
+      115deg,
+      var(--etch) 0 1px,
+      transparent 1px 6px
+    );
+  font-family:
+    ui-sans-serif, system-ui, -apple-system, 'Helvetica Neue', sans-serif;
 }
 
-.hero {
-  position: relative;
-  min-height: max(48rem, calc(100svh - 4rem));
-  overflow: hidden;
-  isolation: isolate;
+:global(html.light) .page {
+  --chassis: #eee7db;
+  --panel: #f6f1e7;
+  --panel-2: #e8e0d1;
+  --line: rgba(20, 45, 40, 0.2);
+  --line-strong: rgba(20, 45, 40, 0.42);
+  --text: #16211f;
+  --muted: rgba(22, 33, 31, 0.68);
+  --signal: #0d7a63;
+  --amber: #9a5a15;
+  --fault: #b1372a;
+  --paper: #fbf8f1;
+  --paper-ink: #14201e;
+  --screen: #061210;
+  --screen-ink: #cffbec;
+  --screen-signal: #86f0d2;
+  --shadow: 0 18px 34px rgba(35, 45, 40, 0.16);
+  --etch: rgba(20, 45, 40, 0.06);
 }
 
-.heroShade {
-  position: absolute;
-  inset: 0;
-  z-index: 0;
-  pointer-events: none;
-  background:
-    linear-gradient(
-      90deg,
-      rgba(3, 7, 10, 0.96) 0%,
-      rgba(3, 7, 10, 0.52) 39%,
-      transparent 70%
-    ),
-    linear-gradient(0deg, rgba(3, 7, 10, 0.98) 0%, transparent 42%);
+@media (prefers-color-scheme: light) {
+  :global(html:not(.dark)) .page {
+  --chassis: #eee7db;
+  --panel: #f6f1e7;
+  --panel-2: #e8e0d1;
+  --line: rgba(20, 45, 40, 0.2);
+  --line-strong: rgba(20, 45, 40, 0.42);
+  --text: #16211f;
+  --muted: rgba(22, 33, 31, 0.68);
+  --signal: #0d7a63;
+  --amber: #9a5a15;
+  --fault: #b1372a;
+  --paper: #fbf8f1;
+  --paper-ink: #14201e;
+  --screen: #061210;
+  --screen-ink: #cffbec;
+  --screen-signal: #86f0d2;
+  --shadow: 0 18px 34px rgba(35, 45, 40, 0.16);
+  --etch: rgba(20, 45, 40, 0.06);
+  }
 }
 
-.sceneFallback {
-  position: absolute;
-  inset: 0;
-  background:
-    radial-gradient(
-      circle at 68% 45%,
-      rgba(144, 205, 194, 0.2),
-      transparent 2%
-    ),
-    radial-gradient(
-      circle at 78% 27%,
-      rgba(77, 134, 173, 0.16),
-      transparent 15%
-    ),
-    radial-gradient(
-      circle at 56% 66%,
-      rgba(226, 174, 102, 0.12),
-      transparent 18%
-    ),
-    #03070a;
+/* ------------------------------------------------------------------ shell */
+
+.bench {
+  max-width: 96rem;
+  margin: 0 auto;
+  padding: clamp(2rem, 5vw, 4rem) clamp(1rem, 4vw, 3rem) clamp(3rem, 6vw, 5rem);
 }
 
-.heroHeading {
-  position: absolute;
-  top: clamp(3.5rem, 9vh, 7rem);
-  left: clamp(1.25rem, 5vw, 5rem);
-  z-index: 2;
-  width: min(40rem, calc(100% - 2.5rem));
+.benchHead {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: clamp(1.5rem, 4vw, 4rem);
+  padding-bottom: clamp(1.5rem, 3vw, 2.5rem);
+  border-bottom: 1px solid var(--line);
 }
 
-.eyebrow,
-.panelEyebrow {
-  margin: 0 0 1.1rem;
-  color: #8fc5bd;
+.eyebrow {
+  display: flex;
+  align-items: center;
+  margin: 0 0 1rem;
+  color: var(--signal);
   font:
-    650 0.65rem/1.3 ui-monospace,
+    650 0.66rem/1 ui-monospace,
     SFMono-Regular,
     Menlo,
     monospace;
-  letter-spacing: 0.17em;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
+  gap: 0.75rem;
 }
 
-.eyebrow::before,
-.panelEyebrow::before {
-  display: inline-block;
-  width: 2.2rem;
+.eyebrow::before {
+  width: 2rem;
   height: 1px;
-  margin: 0 0.75rem 0.2rem 0;
   content: '';
   background: currentColor;
 }
 
-.heroHeading h1 {
-  max-width: 9ch;
+.benchHead h1 {
+  max-width: 18ch;
   margin: 0;
-  color: #f3f0e8;
+  color: var(--text);
   font-family: Georgia, 'Times New Roman', serif;
-  font-size: clamp(3.6rem, 7vw, 7rem);
+  font-size: clamp(2.6rem, 5.6vw, 4.6rem);
   font-weight: 400;
   line-height: 0.88;
-  letter-spacing: -0.06em;
-  text-wrap: balance;
-  text-shadow: 0 0 3rem #03070a;
+  letter-spacing: -0.045em;
 }
 
-.heroHeading > p:not(.eyebrow) {
-  max-width: 38rem;
-  margin: 1.6rem 0 0;
-  color: rgba(220, 235, 230, 0.68);
-  font-size: clamp(0.95rem, 1.25vw, 1.08rem);
-  line-height: 1.7;
+.lede {
+  max-width: 46rem;
+  margin: 1.4rem 0 0;
+  color: var(--muted);
+  font-size: clamp(0.95rem, 1.1vw, 1.06rem);
+  line-height: 1.72;
 }
 
-.readLink {
-  display: inline-flex;
-  margin-top: 1.6rem;
-  padding-bottom: 0.35rem;
-  gap: 0.65rem;
-  border-bottom: 1px solid rgba(191, 228, 220, 0.4);
-  color: #bfe4dc;
-  font:
-    650 0.63rem/1 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  letter-spacing: 0.11em;
-  text-transform: uppercase;
-}
-
-.explorer {
-  position: absolute;
-  right: clamp(1.25rem, 4vw, 4rem);
-  bottom: clamp(2rem, 5vh, 4rem);
-  left: clamp(1.25rem, 5vw, 5rem);
-  z-index: 3;
+.statusStack {
   display: grid;
-  grid-template-columns: minmax(29rem, 1fr) minmax(23rem, 30rem);
-  gap: clamp(2rem, 7vw, 7rem);
-  align-items: end;
-}
-
-.chapterNav {
-  display: grid;
-  padding-top: 0.6rem;
-  grid-template-columns: repeat(7, minmax(4.5rem, 1fr));
-  border-top: 1px solid rgba(191, 228, 220, 0.18);
-  gap: 0.3rem;
-}
-
-.chapterButton,
-.chapterButtonActive {
-  min-height: 3.5rem;
-  padding: 0.55rem 0.45rem;
-  border: 0;
-  border-radius: 0.15rem;
-  color: rgba(220, 235, 230, 0.48);
-  background: rgba(3, 8, 10, 0.58);
-  font:
-    600 0.56rem/1.25 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  letter-spacing: 0.07em;
-  text-align: left;
-  text-transform: uppercase;
-  cursor: pointer;
-  backdrop-filter: blur(12px);
-  transition:
-    color 160ms ease,
-    background 160ms ease;
-}
-
-.chapterButton span,
-.chapterButtonActive span {
-  display: block;
-  margin-bottom: 0.35rem;
-  color: rgba(191, 228, 220, 0.3);
-}
-
-.chapterButton:hover,
-.chapterButtonActive {
-  color: #edf3ee;
-  background: rgba(42, 104, 98, 0.46);
-}
-
-.activeChapter {
-  min-height: 18rem;
-  padding: 1.5rem;
-  border: 1px solid rgba(191, 228, 220, 0.18);
-  background: rgba(4, 12, 15, 0.8);
-  box-shadow: 0 1.5rem 5rem rgba(0, 0, 0, 0.24);
-  backdrop-filter: blur(18px);
-}
-
-.panelEyebrow {
-  margin-bottom: 1.3rem;
-  font-size: 0.58rem;
-}
-
-.chapterTitleRow {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 1rem;
-  align-items: start;
-}
-
-.chapterTitleRow > span {
-  padding-top: 0.42rem;
-  color: rgba(191, 228, 220, 0.38);
-  font:
-    600 0.6rem/1 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-}
-
-.chapterTitleRow h2 {
   margin: 0;
-  color: #eef2ed;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  background: var(--panel);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  gap: 0.55rem;
+  list-style: none;
+}
+
+.statusStack li {
+  display: flex;
+  align-items: center;
+  color: var(--muted);
+  font:
+    650 0.6rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.13em;
+  white-space: nowrap;
+  gap: 0.55rem;
+}
+
+.ledOk,
+.ledAmber,
+.ledSignal {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  flex: none;
+}
+
+.ledOk {
+  background: #4ad995;
+  box-shadow: 0 0 0.5rem rgba(74, 217, 149, 0.8);
+}
+
+.ledAmber {
+  background: var(--amber);
+  box-shadow: 0 0 0.5rem rgba(240, 180, 90, 0.6);
+}
+
+.ledSignal {
+  background: var(--signal);
+  box-shadow: 0 0 0.55rem var(--signal);
+  animation: blink 2.4s steps(1, end) infinite;
+}
+
+@keyframes blink {
+  0%,
+  62% {
+    opacity: 1;
+  }
+  63%,
+  74% {
+    opacity: 0.25;
+  }
+  75%,
+  100% {
+    opacity: 1;
+  }
+}
+
+/* -------------------------------------------------------------- instrument */
+
+.instrument {
+  display: grid;
+  margin-top: clamp(1.5rem, 3vw, 2.25rem);
+  grid-template-areas:
+    'viewport scope'
+    'channels scope';
+  grid-template-columns: minmax(0, 1fr) minmax(21rem, 27rem);
+  grid-template-rows: auto auto;
+  gap: clamp(0.9rem, 1.6vw, 1.4rem);
+}
+
+.viewport {
+  position: relative;
+  grid-area: viewport;
+  padding: 0.75rem;
+  border: 1px solid var(--line-strong);
+  border-radius: 4px;
+  background:
+    radial-gradient(circle at 0.95rem 0.95rem, var(--line-strong) 0 2.5px, transparent 3px),
+    radial-gradient(circle at calc(100% - 0.95rem) 0.95rem, var(--line-strong) 0 2.5px, transparent 3px),
+    radial-gradient(circle at 0.95rem calc(100% - 0.95rem), var(--line-strong) 0 2.5px, transparent 3px),
+    radial-gradient(
+      circle at calc(100% - 0.95rem) calc(100% - 0.95rem),
+      var(--line-strong) 0 2.5px,
+      transparent 3px
+    ),
+    linear-gradient(180deg, var(--panel-2), var(--panel));
+  box-shadow: var(--shadow), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.viewportInner {
+  position: relative;
+  overflow: hidden;
+  aspect-ratio: 16 / 10;
+  border: 1px solid var(--line);
+  border-radius: 2px;
+  background: var(--chassis);
+}
+
+.sceneLoading {
+  width: 100%;
+  height: 100%;
+  background:
+    radial-gradient(circle at 50% 55%, rgba(134, 240, 210, 0.08), transparent 60%),
+    var(--chassis);
+}
+
+.viewportRail {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.6rem 0.15rem 0.1rem;
+  gap: 1rem;
+}
+
+.railTag {
+  overflow: hidden;
+  color: var(--muted);
+  font:
+    650 0.58rem/1.2 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.13em;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.coach {
+  position: absolute;
+  right: 1.5rem;
+  bottom: 3rem;
+  display: grid;
+  margin: 0;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid var(--signal);
+  border-radius: 3px;
+  color: var(--text);
+  background: color-mix(in srgb, var(--panel) 88%, transparent);
+  font:
+    650 0.6rem/1.5 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  gap: 0.15rem;
+  animation: coachPulse 2.6s ease-in-out infinite;
+}
+
+@keyframes coachPulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(134, 240, 210, 0.4);
+  }
+  50% {
+    box-shadow: 0 0 0 0.5rem rgba(134, 240, 210, 0);
+  }
+}
+
+/* ---------------------------------------------------------------- channels */
+
+.channels {
+  grid-area: channels;
+  padding: 0.85rem 0.9rem 1rem;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: linear-gradient(180deg, var(--panel-2), var(--panel));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.channelsLabel {
+  margin: 0 0 0.7rem;
+  color: var(--muted);
+  font:
+    650 0.58rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.channelGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(8.5rem, 1fr));
+  gap: 0.5rem;
+}
+
+.channel,
+.channelActive {
+  display: grid;
+  min-height: 3.6rem;
+  padding: 0.55rem 0.6rem;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  color: var(--text);
+  background: linear-gradient(180deg, var(--panel-2), var(--panel));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.07),
+    0 2px 0 rgba(0, 0, 0, 0.35);
+  cursor: pointer;
+  gap: 0.3rem;
+  text-align: left;
+  transition:
+    transform 0.09s ease,
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
+}
+
+.channel:hover {
+  border-color: var(--line-strong);
+  transform: translateY(-1px);
+}
+
+.channelActive {
+  border-color: var(--signal);
+  background: linear-gradient(180deg, var(--panel), var(--panel-2));
+  box-shadow:
+    inset 0 2px 6px rgba(0, 0, 0, 0.45),
+    0 0 0 1px color-mix(in srgb, var(--signal) 35%, transparent);
+  transform: translateY(1px);
+}
+
+.channelDesignator {
+  display: flex;
+  align-items: center;
+  color: var(--muted);
+  font:
+    700 0.68rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.12em;
+  gap: 0.4rem;
+}
+
+.channelActive .channelDesignator {
+  color: var(--signal);
+}
+
+.channelDesignator i {
+  width: 0.42rem;
+  height: 0.42rem;
+  border-radius: 50%;
+  background: var(--line-strong);
+}
+
+.channelActive .channelDesignator i {
+  background: var(--signal);
+  box-shadow: 0 0 0.5rem var(--signal);
+}
+
+.channelName {
+  font-size: 0.82rem;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+}
+
+/* ------------------------------------------------------------------ scope */
+
+.scopeColumn {
+  grid-area: scope;
+  scroll-margin-top: 5rem;
+}
+
+.scope {
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+  border: 1px solid var(--line-strong);
+  border-radius: 4px;
+  background: linear-gradient(180deg, var(--panel-2), var(--panel));
+  box-shadow: var(--shadow), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.scopeHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.7rem 0.85rem;
+  border-bottom: 1px solid var(--line);
+  color: var(--muted);
+  font:
+    650 0.58rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.13em;
+  gap: 0.6rem;
+  text-transform: uppercase;
+}
+
+.scopeChannel {
+  display: flex;
+  align-items: center;
+  color: var(--signal);
+  gap: 0.45rem;
+}
+
+.scopeHeadRight {
+  color: var(--amber);
+}
+
+.screen {
+  position: relative;
+  overflow: hidden;
+  height: 8.5rem;
+  margin: 0.85rem;
+  border: 1px solid rgba(134, 240, 210, 0.28);
+  border-radius: 2px;
+  background-color: var(--screen);
+  background-image:
+    linear-gradient(rgba(134, 240, 210, 0.11) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(134, 240, 210, 0.11) 1px, transparent 1px);
+  background-position: center center;
+  background-size: 12.5% 20%, 12.5% 20%;
+  box-shadow: inset 0 0 2.5rem rgba(0, 0, 0, 0.75);
+}
+
+.trace {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.trace path {
+  fill: none;
+  stroke: var(--screen-signal);
+  stroke-width: 2px;
+  stroke-linecap: square;
+  filter: drop-shadow(0 0 4px rgba(134, 240, 210, 0.75));
+  animation: sweep 6s linear infinite;
+}
+
+@keyframes sweep {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-100px);
+  }
+}
+
+.screenTagLeft,
+.screenTagRight,
+.screenScale {
+  position: absolute;
+  color: var(--screen-ink);
+  font:
+    650 0.55rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.screenTagLeft {
+  top: 0.5rem;
+  left: 0.6rem;
+}
+
+.screenTagRight {
+  top: 0.5rem;
+  right: 0.6rem;
+  max-width: 60%;
+  opacity: 0.72;
+  text-align: right;
+}
+
+.screenScale {
+  bottom: 0.5rem;
+  left: 0.6rem;
+  opacity: 0.6;
+}
+
+.readout {
+  padding: 0 1.1rem 1.2rem;
+}
+
+.readoutRole {
+  margin: 0;
+  color: var(--signal);
+  font:
+    650 0.58rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.readoutTitle {
+  margin: 0.6rem 0 0;
   font-family: Georgia, 'Times New Roman', serif;
-  font-size: clamp(1.9rem, 3vw, 2.7rem);
+  font-size: clamp(1.6rem, 2.4vw, 2.1rem);
   font-weight: 400;
-  line-height: 1;
+  line-height: 1.05;
   letter-spacing: -0.03em;
 }
 
-.chapterMeta {
-  margin: 0.65rem 0 0 2.35rem;
-  color: #8fc5bd;
-  font:
-    600 0.6rem/1.4 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  letter-spacing: 0.09em;
-  text-transform: uppercase;
-}
-
-.chapterText {
-  margin: 1.15rem 0 0 2.35rem;
-  color: rgba(220, 235, 230, 0.66);
-  font-size: 0.9rem;
-  line-height: 1.68;
-}
-
-.visualNote {
-  position: absolute;
-  right: 1rem;
-  bottom: 0.65rem;
-  z-index: 4;
-  margin: 0;
-  color: rgba(220, 235, 230, 0.34);
-  font:
-    500 0.52rem/1.3 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.narrative,
-.range,
-.principles,
-.nextSignal {
-  padding: clamp(5rem, 9vw, 9rem) clamp(1.25rem, 6vw, 6rem);
-}
-
-.narrative {
-  color: #132523;
-  background: #e8eee8;
-}
-
-.narrative .eyebrow,
-.range .eyebrow {
-  color: #39756f;
-}
-
-.sectionIntro,
-.rangeHeading,
-.nextSignal {
-  display: grid;
-  grid-template-columns: minmax(0, 0.9fr) minmax(20rem, 0.65fr);
-  gap: clamp(3rem, 8vw, 8rem);
-  align-items: end;
-}
-
-.sectionIntro,
-.evidenceGrid,
-.rangeHeading,
-.rangeBands,
-.principlesHeading,
-.principleGrid {
-  width: min(100%, 82rem);
-  margin-right: auto;
-  margin-left: auto;
-}
-
-.sectionIntro h2,
-.rangeHeading h2,
-.principlesHeading h2,
-.nextSignal h2 {
-  max-width: 12ch;
-  margin: 0;
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: clamp(2.8rem, 5.4vw, 5.5rem);
-  font-weight: 400;
-  line-height: 0.96;
-  letter-spacing: -0.05em;
+.readoutHead {
+  margin: 0.7rem 0 0;
+  color: var(--text);
+  font-size: 1rem;
+  line-height: 1.5;
   text-wrap: balance;
 }
 
-.sectionIntro > p,
-.rangeHeading > p,
-.nextCopy > p {
-  margin: 0;
-  color: rgba(19, 37, 35, 0.68);
-  font-size: clamp(1rem, 1.45vw, 1.15rem);
-  line-height: 1.75;
+.readoutBody {
+  margin: 0.75rem 0 0;
+  color: var(--muted);
+  font-size: 0.88rem;
+  line-height: 1.72;
 }
 
-.evidenceGrid {
+.measured {
   display: grid;
-  margin-top: clamp(3.5rem, 7vw, 6.5rem);
-  grid-template-columns: 1.15fr 1fr 1fr;
-  gap: 1px;
-  background: rgba(25, 58, 54, 0.18);
+  margin: 1.1rem 0 0;
+  border-top: 1px solid var(--line);
 }
 
-.evidenceCard {
-  display: flex;
-  min-height: 26rem;
-  padding: 1.5rem;
-  flex-direction: column;
-  justify-content: space-between;
-  background: #edf1eb;
+.measured > div {
+  display: grid;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--line);
+  grid-template-columns: 7.5rem minmax(0, 1fr);
+  gap: 0.75rem;
 }
 
-.evidenceCardPrimary {
-  color: #e8f0eb;
-  background:
-    radial-gradient(
-      circle at 76% 24%,
-      rgba(107, 185, 174, 0.16),
-      transparent 24%
-    ),
-    #071215;
-}
-
-.cardTopline {
-  display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-  color: rgba(19, 37, 35, 0.48);
+.measured dt {
+  color: var(--muted);
   font:
-    600 0.57rem/1.3 ui-monospace,
+    650 0.56rem/1.4 ui-monospace,
     SFMono-Regular,
     Menlo,
     monospace;
-  letter-spacing: 0.09em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
-.evidenceCardPrimary .cardTopline {
-  color: rgba(220, 235, 230, 0.45);
-}
-
-.evidenceCard h3 {
+.measured dd {
   margin: 0;
-  color: inherit;
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: clamp(2rem, 3.2vw, 3.2rem);
-  font-weight: 400;
-  line-height: 1;
-  letter-spacing: -0.04em;
+  font-size: 0.8rem;
+  line-height: 1.4;
 }
 
-.evidenceCard p {
-  margin: 1.1rem 0 0;
-  color: rgba(19, 37, 35, 0.66);
-  font-size: 0.9rem;
-  line-height: 1.68;
+.chips {
+  display: flex;
+  margin: 1rem 0 0;
+  padding: 0;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  list-style: none;
 }
 
-.evidenceCardPrimary p {
-  color: rgba(220, 235, 230, 0.62);
-}
-
-.range {
-  color: #17302e;
-  background: #dce6df;
-}
-
-.rangeBands {
-  display: grid;
-  margin-top: clamp(3rem, 6vw, 5rem);
-  border-top: 1px solid rgba(25, 58, 54, 0.2);
-}
-
-.rangeBands > div {
-  display: grid;
-  min-height: 5.5rem;
-  padding: 1.2rem 0;
-  grid-template-columns: 4rem 1fr minmax(12rem, 0.6fr);
-  gap: 1rem;
-  border-bottom: 1px solid rgba(25, 58, 54, 0.16);
-  align-items: center;
-}
-
-.rangeBands span,
-.rangeBands small {
-  color: rgba(23, 48, 46, 0.5);
+.chips li {
+  padding: 0.3rem 0.5rem;
+  border: 1px solid var(--line);
+  border-radius: 2px;
+  color: var(--muted);
   font:
-    600 0.62rem/1.4 ui-monospace,
+    600 0.58rem/1 ui-monospace,
     SFMono-Regular,
     Menlo,
     monospace;
@@ -407,209 +609,464 @@
   text-transform: uppercase;
 }
 
-.rangeBands strong {
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: clamp(1.4rem, 2.4vw, 2.1rem);
-  font-weight: 400;
+.readoutLinks {
+  display: flex;
+  margin-top: 1.1rem;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
-.principles {
-  border-top: 1px solid rgba(191, 228, 220, 0.08);
-  background:
-    radial-gradient(circle at 78% 22%, rgba(42, 99, 94, 0.18), transparent 25%),
-    #050b0e;
-}
-
-.principlesHeading h2 {
-  max-width: 15ch;
-  color: #f0f1eb;
-}
-
-.principleGrid {
-  display: grid;
-  margin-top: clamp(3.5rem, 7vw, 6rem);
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1px;
-  background: rgba(191, 228, 220, 0.12);
-}
-
-.principleGrid article {
-  min-height: 19rem;
-  padding: 1.5rem;
-  background: rgba(6, 16, 19, 0.96);
-}
-
-.principleGrid span {
-  color: rgba(191, 228, 220, 0.38);
+.linkButton {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.55rem 0.8rem;
+  border: 1px solid var(--signal);
+  border-radius: 2px;
+  color: var(--signal);
   font:
-    600 0.62rem/1 ui-monospace,
+    650 0.6rem/1 ui-monospace,
     SFMono-Regular,
     Menlo,
     monospace;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  gap: 0.45rem;
 }
 
-.principleGrid h3 {
-  margin: 5rem 0 0;
-  color: #edf1eb;
+.linkButton:hover {
+  color: var(--chassis);
+  background: var(--signal);
+}
+
+/* -------------------------------------------------------------------- BOM */
+
+.bom {
+  padding: clamp(3rem, 6vw, 5.5rem) clamp(1rem, 4vw, 3rem);
+  color: var(--paper-ink);
+  background: var(--paper);
+  background-image: repeating-linear-gradient(
+    0deg,
+    rgba(20, 32, 30, 0.045) 0 1px,
+    transparent 1px 2.35rem
+  );
+}
+
+.sectionHead {
+  max-width: 96rem;
+  margin: 0 auto clamp(2rem, 4vw, 3rem);
+}
+
+.bom .eyebrow {
+  color: #1c6f5c;
+}
+
+.sectionHead h2 {
+  max-width: 20ch;
+  margin: 0;
   font-family: Georgia, 'Times New Roman', serif;
-  font-size: clamp(1.8rem, 3vw, 2.7rem);
+  font-size: clamp(2rem, 4.2vw, 3.2rem);
   font-weight: 400;
-  line-height: 1;
+  line-height: 0.95;
+  letter-spacing: -0.035em;
 }
 
-.principleGrid p {
+.sectionHead p:not(.eyebrow) {
+  max-width: 44rem;
   margin: 1rem 0 0;
-  color: rgba(220, 235, 230, 0.58);
-  font-size: 0.89rem;
-  line-height: 1.68;
+  font-size: 0.95rem;
+  line-height: 1.7;
+  opacity: 0.72;
 }
 
-.nextSignal {
-  width: min(100%, 94rem);
+.bomList {
+  max-width: 96rem;
   margin: 0 auto;
-  background: #03070a;
+  padding: 0;
+  border-top: 2px solid rgba(20, 32, 30, 0.45);
+  list-style: none;
+  counter-reset: bom;
 }
 
-.nextSignal h2 {
-  max-width: 14ch;
-  color: #f1f0e9;
+.bomList > li {
+  border-bottom: 1px solid rgba(20, 32, 30, 0.22);
 }
 
-.nextCopy > p {
-  color: rgba(220, 235, 230, 0.6);
+.bomRow {
+  display: grid;
+  padding: clamp(1.4rem, 2.5vw, 2rem) 0;
+  grid-template-columns: minmax(0, 15rem) minmax(0, 1fr);
+  gap: clamp(1rem, 4vw, 3.5rem);
 }
 
-.nextLinks {
+.bomDesignator {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid rgba(20, 32, 30, 0.4);
+  color: #14201e;
+  background: rgba(20, 32, 30, 0.06);
+  font:
+    700 0.66rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.12em;
+}
+
+.bomIdent h3 {
+  margin: 0.7rem 0 0;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: 1.5rem;
+  font-weight: 400;
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+}
+
+.bomRole,
+.bomNet {
+  margin: 0.4rem 0 0;
+  font:
+    600 0.58rem/1.5 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  opacity: 0.66;
+}
+
+.bomNet {
+  color: #1c6f5c;
+  opacity: 0.9;
+}
+
+.bomHead {
+  margin: 0;
+  font-size: clamp(1.05rem, 1.6vw, 1.3rem);
+  line-height: 1.35;
+  letter-spacing: -0.015em;
+  text-wrap: balance;
+}
+
+.bomText p:not(.bomHead) {
+  margin: 0.75rem 0 0;
+  max-width: 62ch;
+  font-size: 0.95rem;
+  line-height: 1.72;
+  opacity: 0.78;
+}
+
+.bomText .chips li {
+  border-color: rgba(20, 32, 30, 0.28);
+  color: rgba(20, 32, 30, 0.75);
+}
+
+/* ------------------------------------------------------------------- spec */
+
+.spec {
+  padding: clamp(3rem, 6vw, 5.5rem) clamp(1rem, 4vw, 3rem) clamp(4rem, 8vw, 7rem);
+  background:
+    repeating-linear-gradient(115deg, var(--etch) 0 1px, transparent 1px 6px),
+    var(--chassis);
+}
+
+.specInner {
+  max-width: 96rem;
+  margin: 0 auto;
+}
+
+.spec .sectionHead {
+  margin-bottom: clamp(1.5rem, 3vw, 2.25rem);
+}
+
+.spec .sectionHead h2 {
+  color: var(--text);
+}
+
+.specGrid {
+  display: grid;
+  margin: 0;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: linear-gradient(180deg, var(--panel-2), var(--panel));
+  grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
+}
+
+.specGrid > div {
+  padding: 1rem 1.1rem;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.specGrid dt {
+  color: var(--signal);
+  font:
+    650 0.56rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.specGrid dd {
+  margin: 0.5rem 0 0;
+  color: var(--text);
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.specActions {
   display: flex;
-  margin-top: 1.8rem;
+  margin-top: 1.5rem;
   flex-wrap: wrap;
-  gap: 1.5rem;
+  gap: 0.6rem;
 }
 
-.nextLinks a {
+.primaryAction,
+.secondaryAction {
   display: inline-flex;
-  padding-bottom: 0.35rem;
-  gap: 0.6rem;
-  border-bottom: 1px solid rgba(191, 228, 220, 0.32);
-  color: #bfe4dc;
+  align-items: center;
+  min-height: 3rem;
+  padding: 0 1.1rem;
+  border: 1px solid var(--signal);
+  border-radius: 3px;
   font:
     650 0.64rem/1 ui-monospace,
     SFMono-Regular,
     Menlo,
     monospace;
-  letter-spacing: 0.09em;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  gap: 0.5rem;
+}
+
+.primaryAction {
+  color: var(--chassis);
+  background: var(--signal);
+  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.4);
+}
+
+.secondaryAction {
+  color: var(--signal);
+  background: transparent;
+}
+
+.primaryAction:active,
+.secondaryAction:active {
+  transform: translateY(1px);
+}
+
+.secondaryAction:hover {
+  background: color-mix(in srgb, var(--signal) 14%, transparent);
+}
+
+/* --------------------------------------------------------- rack elevation */
+
+.planWrap {
+  width: 100%;
+  height: 100%;
+  padding: 0.75rem;
+  background: var(--chassis);
+}
+
+.plan {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.planFrame {
+  fill: none;
+}
+
+.planUnit rect:first-of-type,
+.planUnitActive rect:first-of-type {
+  fill: var(--panel-2);
+  stroke: var(--line-strong);
+  stroke-width: 3;
+  cursor: pointer;
+}
+
+.planUnitActive rect:first-of-type {
+  stroke: var(--signal);
+  stroke-width: 5;
+}
+
+.planUnit text,
+.planUnitActive text {
+  fill: var(--text);
+  font:
+    700 30px ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  pointer-events: none;
+}
+
+.planSlot {
+  fill: var(--signal) !important;
+}
+
+.planMeta {
+  font-size: 22px !important;
+  font-weight: 500 !important;
+  opacity: 0.6;
+}
+
+.planMeterBg {
+  fill: #05100e;
+  stroke: var(--line);
+  stroke-width: 2;
+}
+
+.planMeterFill {
+  fill: var(--signal);
+}
+
+
+/* ------------------------------------------------------------- meter block */
+
+.meterBlock {
+  padding: 0 1.1rem 0.9rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.meterLabel {
+  margin: 0;
+  color: var(--muted);
+  font:
+    650 0.56rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.15em;
   text-transform: uppercase;
 }
 
-@media (max-width: 1000px) {
-  .hero {
-    min-height: 60rem;
+.meterValue {
+  display: flex;
+  align-items: baseline;
+  margin: 0.45rem 0 0;
+  font:
+    650 1rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  gap: 0.55rem;
+}
+
+.meterFrom {
+  color: var(--muted);
+}
+
+.meterArrow {
+  color: var(--amber);
+}
+
+.meterValue strong {
+  color: var(--signal);
+  font-size: clamp(2rem, 3.4vw, 2.9rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  font-variant-numeric: tabular-nums;
+}
+
+.meterNote {
+  margin: 0.4rem 0 0;
+  color: var(--muted);
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
+.bomMetrics {
+  display: grid;
+  margin: 1rem 0 0;
+  border-top: 1px solid rgba(20, 32, 30, 0.25);
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+}
+
+.bomMetrics > div {
+  padding: 0.55rem 0.9rem 0.55rem 0;
+  border-bottom: 1px solid rgba(20, 32, 30, 0.16);
+}
+
+.bomMetrics dt {
+  font:
+    650 0.55rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  opacity: 0.55;
+}
+
+.bomMetrics dd {
+  margin: 0.3rem 0 0;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.patchNote {
+  margin: 1.5rem 0 0;
+  color: var(--muted);
+  font:
+    600 0.58rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+/* ------------------------------------------------------------- responsive */
+
+@media (max-width: 1080px) {
+  .instrument {
+    grid-template-areas:
+      'viewport'
+      'channels'
+      'scope';
+    grid-template-columns: minmax(0, 1fr);
   }
 
-  .heroShade {
-    background: linear-gradient(
-      0deg,
-      rgba(3, 7, 10, 0.99) 0%,
-      rgba(3, 7, 10, 0.42) 67%,
-      rgba(3, 7, 10, 0.64) 100%
-    );
+  .benchHead {
+    grid-template-columns: minmax(0, 1fr);
   }
 
-  .heroHeading {
-    top: 3.5rem;
-  }
-
-  .explorer {
-    grid-template-columns: 1fr;
-    gap: 1rem;
-  }
-
-  .chapterNav {
-    order: 2;
-    overflow-x: auto;
-    scrollbar-width: none;
-  }
-
-  .chapterButton,
-  .chapterButtonActive {
-    min-width: 6.5rem;
-  }
-
-  .activeChapter {
-    width: min(100%, 34rem);
-    min-height: 16rem;
-  }
-
-  .evidenceGrid,
-  .principleGrid {
-    grid-template-columns: 1fr;
-  }
-
-  .evidenceCard {
-    min-height: 21rem;
-  }
-
-  .principleGrid article {
-    min-height: 16rem;
-  }
-
-  .principleGrid h3 {
-    margin-top: 3rem;
+  .statusStack {
+    grid-auto-flow: column;
+    justify-content: start;
+    gap: 1.25rem;
   }
 }
 
 @media (max-width: 720px) {
-  .hero {
-    min-height: 64rem;
+  .viewportInner {
+    aspect-ratio: 4 / 3;
   }
 
-  .heroHeading {
-    top: 2.7rem;
+  .bomRow {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1rem;
   }
 
-  .heroHeading h1 {
-    font-size: clamp(3.35rem, 16vw, 5rem);
+  .measured > div {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.15rem;
   }
 
-  .explorer {
-    right: 1rem;
-    bottom: 2.2rem;
-    left: 1rem;
-  }
-
-  .activeChapter {
-    min-height: 19rem;
-    padding: 1.2rem;
-  }
-
-  .chapterText,
-  .chapterMeta {
-    margin-left: 0;
-  }
-
-  .visualNote {
-    display: none;
-  }
-
-  .sectionIntro,
-  .rangeHeading,
-  .nextSignal {
-    grid-template-columns: 1fr;
-    gap: 2rem;
-  }
-
-  .rangeBands > div {
-    grid-template-columns: 2.5rem 1fr;
-  }
-
-  .rangeBands small {
-    grid-column: 2;
+  .coach {
+    right: 0.75rem;
+    bottom: 2.6rem;
+    left: 0.75rem;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .chapterButton,
-  .chapterButtonActive {
-    transition: none;
+  .trace path,
+  .ledSignal,
+  .coach {
+    animation: none;
   }
 }

--- a/app/career/page.tsx
+++ b/app/career/page.tsx
@@ -4,7 +4,7 @@ import { CareerExperience } from './career-experience'
 export const metadata: Metadata = {
   title: 'Career | Devon Bull',
   description:
-    'Devon Bull’s experience across embedded client work, full-stack platforms, consulting, and engineering leadership.',
+    'Devon Bull — Solutions Architect at Big Nerd Ranch. Backend lead on Apple’s chatbot (1M → 15M users), engineering lead on Chick-fil-A third-party delivery (<$1M → $5M per day).',
   alternates: { canonical: '/career' }
 }
 

--- a/app/systems/page.tsx
+++ b/app/systems/page.tsx
@@ -4,7 +4,7 @@ import { SystemsExperience } from './systems-experience'
 export const metadata: Metadata = {
   title: 'Systems | Devon Bull',
   description:
-    'Explore how Devon Bull connects interfaces, services, data, cloud infrastructure, delivery feedback, and AI tooling.',
+    'A playable cutaway of a third-party delivery order crossing a platform: edge, service, data, runtime, feedback — with fault injection and the decisions behind each stage.',
   alternates: { canonical: '/systems' }
 }
 

--- a/app/systems/systems-data.ts
+++ b/app/systems/systems-data.ts
@@ -1,0 +1,105 @@
+// /systems content. Grounded in Devon's real engagements (Apple chatbot 2018-2020,
+// Chick-fil-A third-party delivery 2020-2022). No invented metrics.
+
+export type Stage = {
+  id: string
+  index: number
+  code: string
+  name: string
+  strap: string
+  what: string
+  decision: string
+  faultLine: string
+  faultDetail: string
+  tools: string[]
+  evidence: { label: string; value: string }[]
+}
+
+export const stages: Stage[] = [
+  {
+    id: 'edge',
+    index: 0,
+    code: '01',
+    name: 'Edge',
+    strap: 'The interface nobody else has to keep stable',
+    what: 'Three delivery partners push orders in — DoorDash, UberEats, Grubhub — and the Chick-fil-A iOS app pulls checkout back out. Four clients, four contracts, none of them versioned on my schedule.',
+    decision: 'The most interesting edge decision was letting somebody else own part of the flow: we worked with DoorDash’s engineers to put DoorDash checkout inside the Chick-fil-A app. More coordination, but the order never left the customer’s funnel.',
+    faultLine: 'partner endpoint refusing connections',
+    faultDetail: 'A partner going down is not an outage you can fix — it is an outage you have to absorb. Orders queue at the door, the app tells the truth about what it can do, and nothing silently disappears.',
+    tools: ['DoorDash', 'UberEats', 'Grubhub', 'iOS app', 'REST/JSON'],
+    evidence: [
+      { label: 'Scale', value: '<$1M/day → $5M/day in delivery revenue' },
+      { label: 'Shipped', value: 'DoorDash checkout inside the Chick-fil-A app' }
+    ]
+  },
+  {
+    id: 'service',
+    index: 1,
+    code: '02',
+    name: 'Service',
+    strap: 'Translate, then refuse to trust',
+    what: 'The integration service turns three partner order shapes into one internal order and then answers for it. Node and Express, Go where throughput and a single binary helped, TypeScript for the contracts.',
+    decision: 'Every partner retries, so every write is idempotent and the partner order id is the natural key. The second copy of an order is a no-op, not a second lunch. Modelling combo meals properly for UberEats was worth roughly ten percent more revenue per order — a data-modelling decision, not a growth hack.',
+    faultLine: 'service instance terminated mid-request',
+    faultDetail: 'Losing an instance should be boring. Requests retry onto a healthy one and idempotency keeps the order single — the failure is only visible in the graph, not on the receipt.',
+    tools: ['Node', 'Express', 'Go', 'TypeScript', 'Mongoose'],
+    evidence: [
+      { label: 'Revenue per order', value: '~10% higher with UberEats combo meals' },
+      { label: 'Contract rule', value: 'Idempotent writes keyed on partner order id' }
+    ]
+  },
+  {
+    id: 'data',
+    index: 2,
+    code: '03',
+    name: 'Data',
+    strap: 'Pick the access pattern before the database',
+    what: 'MongoDB, DynamoDB and Postgres in production, each because of how the data is read rather than which one is fashionable.',
+    decision: 'Order state is written once and read by key, so DynamoDB. Menus are documents whose shape differs per partner, so Mongo. Anything that has to answer a question with a join stays in Postgres. Choosing the store by taste is how a team earns a migration nobody scheduled.',
+    faultLine: 'write throttled, connection pool saturated',
+    faultDetail: 'Throttling is the honest failure: the store is telling you the truth about capacity. The order buffers, the breaker opens so we stop making it worse, and the queue drains once the write path recovers.',
+    tools: ['DynamoDB', 'MongoDB', 'Postgres'],
+    evidence: [
+      { label: 'Rule', value: 'Access pattern first, engine second' },
+      { label: 'Stores run', value: '3 in production' }
+    ]
+  },
+  {
+    id: 'runtime',
+    index: 3,
+    code: '04',
+    name: 'Runtime',
+    strap: 'Boring deploys, reviewable infrastructure',
+    what: 'AWS, Docker, Kubernetes and GitHub Actions. The environment is an artifact somebody reviewed, not something a person remembers.',
+    decision: 'I oversaw migrating the delivery project’s infrastructure to AWS CloudFormation so the environment became a diffable file. On the Apple engagement the same instinct applied to the runtime itself: Node 5 to Node 12, ES5 to ES6, under a product that was never allowed to go offline — shipped in slices while the fleet stayed up.',
+    faultLine: 'bad release detected, rolling back',
+    faultDetail: 'A rollback should be the cheapest action available. If rolling back is scary, every other decision in the system gets more expensive.',
+    tools: ['AWS', 'CloudFormation', 'Docker', 'Kubernetes', 'GitHub Actions'],
+    evidence: [
+      { label: 'Migration', value: 'Project infrastructure → AWS CloudFormation' },
+      { label: 'Apple runtime', value: 'Node 5 → 12, ES5 → ES6, zero downtime' }
+    ]
+  },
+  {
+    id: 'feedback',
+    index: 4,
+    code: '05',
+    name: 'Feedback',
+    strap: 'See it before the partner calls',
+    what: 'Datadog, Splunk and OpsGenie, wired to the things a customer would feel: orders not acknowledged, partner latency climbing, queue depth growing.',
+    decision: 'Alerting on symptoms instead of resources is the difference between an on-call rotation and a fire drill. Through Covid the traffic curve changed every week; the only way to hold uptime while daily revenue went 5× — or while a platform goes from one million to fifteen million users, as Apple’s did — is to watch the thing the customer notices.',
+    faultLine: 'telemetry pipeline silent',
+    faultDetail: 'The worst failure on this diagram. Everything keeps working and nobody can prove it. Blind systems feel fine right up until they are not.',
+    tools: ['Datadog', 'Splunk', 'OpsGenie'],
+    evidence: [
+      { label: 'Apple', value: '1M → 15M users, 100% uptime' },
+      { label: 'Chick-fil-A', value: 'Held uptime through Covid demand' }
+    ]
+  }
+]
+
+export const stagesById = Object.fromEntries(
+  stages.map((stage) => [stage.id, stage])
+) as Record<string, Stage>
+
+export const SPEEDS = [0.5, 1, 2, 4] as const

--- a/app/systems/systems-data.ts
+++ b/app/systems/systems-data.ts
@@ -23,13 +23,18 @@ export const stages: Stage[] = [
     name: 'Edge',
     strap: 'The interface nobody else has to keep stable',
     what: 'Three delivery partners push orders in — DoorDash, UberEats, Grubhub — and the Chick-fil-A iOS app pulls checkout back out. Four clients, four contracts, none of them versioned on my schedule.',
-    decision: 'The most interesting edge decision was letting somebody else own part of the flow: we worked with DoorDash’s engineers to put DoorDash checkout inside the Chick-fil-A app. More coordination, but the order never left the customer’s funnel.',
+    decision:
+      'The most interesting edge decision was letting somebody else own part of the flow: we worked with DoorDash’s engineers to put DoorDash checkout inside the Chick-fil-A app. More coordination, but the order never left the customer’s funnel.',
     faultLine: 'partner endpoint refusing connections',
-    faultDetail: 'A partner going down is not an outage you can fix — it is an outage you have to absorb. Orders queue at the door, the app tells the truth about what it can do, and nothing silently disappears.',
+    faultDetail:
+      'A partner going down is not an outage you can fix — it is an outage you have to absorb. Orders queue at the door, the app tells the truth about what it can do, and nothing silently disappears.',
     tools: ['DoorDash', 'UberEats', 'Grubhub', 'iOS app', 'REST/JSON'],
     evidence: [
       { label: 'Scale', value: '<$1M/day → $5M/day in delivery revenue' },
-      { label: 'Shipped', value: 'DoorDash checkout inside the Chick-fil-A app' }
+      {
+        label: 'Shipped',
+        value: 'DoorDash checkout inside the Chick-fil-A app'
+      }
     ]
   },
   {
@@ -39,13 +44,21 @@ export const stages: Stage[] = [
     name: 'Service',
     strap: 'Translate, then refuse to trust',
     what: 'The integration service turns three partner order shapes into one internal order and then answers for it. Node and Express, Go where throughput and a single binary helped, TypeScript for the contracts.',
-    decision: 'Every partner retries, so every write is idempotent and the partner order id is the natural key. The second copy of an order is a no-op, not a second lunch. Modelling combo meals properly for UberEats was worth roughly ten percent more revenue per order — a data-modelling decision, not a growth hack.',
+    decision:
+      'Every partner retries, so every write is idempotent and the partner order id is the natural key. The second copy of an order is a no-op, not a second lunch. Modelling combo meals properly for UberEats was worth roughly ten percent more revenue per order — a data-modelling decision, not a growth hack.',
     faultLine: 'service instance terminated mid-request',
-    faultDetail: 'Losing an instance should be boring. Requests retry onto a healthy one and idempotency keeps the order single — the failure is only visible in the graph, not on the receipt.',
+    faultDetail:
+      'Losing an instance should be boring. Requests retry onto a healthy one and idempotency keeps the order single — the failure is only visible in the graph, not on the receipt.',
     tools: ['Node', 'Express', 'Go', 'TypeScript', 'Mongoose'],
     evidence: [
-      { label: 'Revenue per order', value: '~10% higher with UberEats combo meals' },
-      { label: 'Contract rule', value: 'Idempotent writes keyed on partner order id' }
+      {
+        label: 'Revenue per order',
+        value: '~10% higher with UberEats combo meals'
+      },
+      {
+        label: 'Contract rule',
+        value: 'Idempotent writes keyed on partner order id'
+      }
     ]
   },
   {
@@ -55,9 +68,11 @@ export const stages: Stage[] = [
     name: 'Data',
     strap: 'Pick the access pattern before the database',
     what: 'MongoDB, DynamoDB and Postgres in production, each because of how the data is read rather than which one is fashionable.',
-    decision: 'Order state is written once and read by key, so DynamoDB. Menus are documents whose shape differs per partner, so Mongo. Anything that has to answer a question with a join stays in Postgres. Choosing the store by taste is how a team earns a migration nobody scheduled.',
+    decision:
+      'Order state is written once and read by key, so DynamoDB. Menus are documents whose shape differs per partner, so Mongo. Anything that has to answer a question with a join stays in Postgres. Choosing the store by taste is how a team earns a migration nobody scheduled.',
     faultLine: 'write throttled, connection pool saturated',
-    faultDetail: 'Throttling is the honest failure: the store is telling you the truth about capacity. The order buffers, the breaker opens so we stop making it worse, and the queue drains once the write path recovers.',
+    faultDetail:
+      'Throttling is the honest failure: the store is telling you the truth about capacity. The order buffers, the breaker opens so we stop making it worse, and the queue drains once the write path recovers.',
     tools: ['DynamoDB', 'MongoDB', 'Postgres'],
     evidence: [
       { label: 'Rule', value: 'Access pattern first, engine second' },
@@ -71,12 +86,17 @@ export const stages: Stage[] = [
     name: 'Runtime',
     strap: 'Boring deploys, reviewable infrastructure',
     what: 'AWS, Docker, Kubernetes and GitHub Actions. The environment is an artifact somebody reviewed, not something a person remembers.',
-    decision: 'I oversaw migrating the delivery project’s infrastructure to AWS CloudFormation so the environment became a diffable file. On the Apple engagement the same instinct applied to the runtime itself: Node 5 to Node 12, ES5 to ES6, under a product that was never allowed to go offline — shipped in slices while the fleet stayed up.',
+    decision:
+      'I oversaw migrating the delivery project’s infrastructure to AWS CloudFormation so the environment became a diffable file. On the Apple engagement the same instinct applied to the runtime itself: Node 5 to Node 12, ES5 to ES6, under a product that was never allowed to go offline — shipped in slices while the fleet stayed up.',
     faultLine: 'bad release detected, rolling back',
-    faultDetail: 'A rollback should be the cheapest action available. If rolling back is scary, every other decision in the system gets more expensive.',
+    faultDetail:
+      'A rollback should be the cheapest action available. If rolling back is scary, every other decision in the system gets more expensive.',
     tools: ['AWS', 'CloudFormation', 'Docker', 'Kubernetes', 'GitHub Actions'],
     evidence: [
-      { label: 'Migration', value: 'Project infrastructure → AWS CloudFormation' },
+      {
+        label: 'Migration',
+        value: 'Project infrastructure → AWS CloudFormation'
+      },
       { label: 'Apple runtime', value: 'Node 5 → 12, ES5 → ES6, zero downtime' }
     ]
   },
@@ -87,9 +107,11 @@ export const stages: Stage[] = [
     name: 'Feedback',
     strap: 'See it before the partner calls',
     what: 'Datadog, Splunk and OpsGenie, wired to the things a customer would feel: orders not acknowledged, partner latency climbing, queue depth growing.',
-    decision: 'Alerting on symptoms instead of resources is the difference between an on-call rotation and a fire drill. Through Covid the traffic curve changed every week; the only way to hold uptime while daily revenue went 5× — or while a platform goes from one million to fifteen million users, as Apple’s did — is to watch the thing the customer notices.',
+    decision:
+      'Alerting on symptoms instead of resources is the difference between an on-call rotation and a fire drill. Through Covid the traffic curve changed every week; the only way to hold uptime while daily revenue went 5× — or while a platform goes from one million to fifteen million users, as Apple’s did — is to watch the thing the customer notices.',
     faultLine: 'telemetry pipeline silent',
-    faultDetail: 'The worst failure on this diagram. Everything keeps working and nobody can prove it. Blind systems feel fine right up until they are not.',
+    faultDetail:
+      'The worst failure on this diagram. Everything keeps working and nobody can prove it. Blind systems feel fine right up until they are not.',
     tools: ['Datadog', 'Splunk', 'OpsGenie'],
     evidence: [
       { label: 'Apple', value: '1M → 15M users, 100% uptime' },

--- a/app/systems/systems-experience.tsx
+++ b/app/systems/systems-experience.tsx
@@ -490,7 +490,10 @@ export function SystemsExperience() {
             integrations from 2020 to 2022, through the Covid demand curve that
             took daily delivery revenue from under $1M to $5M. Before that,
             backend lead on Apple’s chatbot while it went from 1M to 15M users
-            with 100% uptime. Both through one consulting firm: Big Nerd Ranch.
+            with 100% uptime. Since then, two years as the sole engineer on
+            Apple’s cloud-resource UI and now Apple’s internal cloud site as it
+            grows into a full developer portal. Seven years, one firm: Stellar
+            Elements, formerly Big Nerd Ranch, an Amdocs company.
           </p>
           <div className={styles.specActions}>
             <Link className={styles.primaryAction} href="/career">

--- a/app/systems/systems-experience.tsx
+++ b/app/systems/systems-experience.tsx
@@ -203,14 +203,14 @@ export function SystemsExperience() {
           <ul className={styles.statusStack} aria-label="Machine status">
             <li>
               <i
-                className={running ? styles.ledOk : styles.ledAmber}
+                className={running && live ? styles.ledOk : styles.ledAmber}
                 aria-hidden="true"
               />
-              {running ? 'RUNNING' : 'HELD'}
+              {!live ? 'STATIC' : running ? 'RUNNING' : 'HELD'}
             </li>
             <li>
               <i className={styles.ledSignal} aria-hidden="true" />
-              {SPEEDS[speedIndex]}× RATE
+              {live ? `${SPEEDS[speedIndex]}× RATE` : 'REDUCED MOTION'}
             </li>
             <li>
               <i

--- a/app/systems/systems-experience.tsx
+++ b/app/systems/systems-experience.tsx
@@ -2,332 +2,439 @@
 
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { SPEEDS, stages, stagesById } from './systems-data'
+import type { MachineEvent } from '@/components/machine/cutaway-scene'
+import {
+  useMachineTheme,
+  usePrefersReducedMotion,
+  useWebglSupported
+} from '@/components/machine/machine-core'
 import styles from './systems.module.css'
 
-const SpaceScene = dynamic(
-  () =>
-    import('@/components/space/space-scene').then(
-      (module) => module.SpaceScene
-    ),
-  {
-    ssr: false,
-    loading: () => <div className={styles.sceneFallback} aria-hidden="true" />
-  }
+const CutawayScene = dynamic(
+  () => import('@/components/machine/cutaway-scene').then((mod) => mod.CutawayScene),
+  { ssr: false, loading: () => <div className={styles.sceneLoading} aria-hidden="true" /> }
 )
 
-const layers = {
-  interface: {
-    number: '01',
-    short: 'Interface',
-    title: 'Product interface',
-    tools: 'TypeScript · React',
-    role: 'Turn complex product behavior into a clear, accessible interaction model.',
-    question: 'Can a person understand and trust what the system is doing?',
-    inputs: 'Product intent · user context',
-    output: 'Usable product surface'
-  },
-  services: {
-    number: '02',
-    short: 'Services',
-    title: 'Application services',
-    tools: 'Node.js · Go',
-    role: 'Shape APIs, integrations, background work, and production services for clarity and change.',
-    question: 'Can the system evolve without making every change risky?',
-    inputs: 'Requests · events · integrations',
-    output: 'Legible system behavior'
-  },
-  data: {
-    number: '03',
-    short: 'Data',
-    title: 'Data model',
-    tools: 'Postgres · DynamoDB · MongoDB',
-    role: 'Choose pragmatic relational, document, or key-value models around the shape of the problem.',
-    question:
-      'Does the model preserve the information the product actually needs?',
-    inputs: 'Domain rules · access patterns',
-    output: 'Durable system state'
-  },
-  runtime: {
-    number: '04',
-    short: 'Runtime',
-    title: 'Cloud runtime',
-    tools: 'AWS · Google Cloud · Kubernetes',
-    role: 'Create infrastructure and operating environments that support safe delivery without hiding production.',
-    question: 'Can the team understand, operate, and recover the system?',
-    inputs: 'Services · configuration · traffic',
-    output: 'Operable production system'
-  },
-  feedback: {
-    number: '05',
-    short: 'Feedback',
-    title: 'Delivery feedback',
-    tools: 'CI/CD · GitHub Actions · Datadog',
-    role: 'Build paved roads, automated checks, and production feedback loops that let teams move with confidence.',
-    question: 'Will the team know quickly when reality diverges from intent?',
-    inputs: 'Code changes · runtime signals',
-    output: 'Safer, faster iteration'
-  },
-  exploration: {
-    number: '06',
-    short: 'AI',
-    title: 'AI exploration',
-    tools: 'Voice · agents · applied tooling',
-    role: 'Explore useful AI interfaces and tools that expand creative leverage while staying grounded in a real workflow.',
-    question: 'Does the new capability make the work meaningfully better?',
-    inputs: 'Model capability · human workflow',
-    output: 'Useful creative leverage'
-  }
-} as const
+type LogLine = { id: number; kind: string; stage: string; text: string; at: number }
 
-type LayerId = keyof typeof layers
-
-const paths = {
-  product: {
-    label: 'Ship a product',
-    description:
-      'Trace intent from the interface through services, state, runtime, and production feedback.',
-    sequence: [
-      'interface',
-      'services',
-      'data',
-      'runtime',
-      'feedback'
-    ] as LayerId[]
-  },
-  operate: {
-    label: 'Operate safely',
-    description:
-      'Start with production feedback, then follow the loop back through runtime and service behavior.',
-    sequence: ['feedback', 'runtime', 'services', 'data'] as LayerId[]
-  },
-  explore: {
-    label: 'Explore AI',
-    description:
-      'Connect a new model capability to an interface, a service boundary, useful state, and a feedback loop.',
-    sequence: [
-      'exploration',
-      'interface',
-      'services',
-      'data',
-      'feedback'
-    ] as LayerId[]
-  }
-} as const
-
-type PathId = keyof typeof paths
-
-const sceneNodeToLayer: Record<string, LayerId> = {
-  typescript: 'interface',
-  react: 'interface',
-  node: 'services',
-  go: 'services',
-  data: 'data',
-  cloud: 'runtime',
-  platform: 'feedback',
-  ai: 'exploration'
+const EVENT_COPY: Record<MachineEvent, { kind: string; text: (stage: string) => string }> = {
+  enter: { kind: 'ok', text: (stage) => `${stage} accepted the request` },
+  fault: { kind: 'err', text: (stage) => `${stage} fault injected` },
+  breaker: { kind: 'warn', text: () => 'retries exhausted · circuit breaker OPEN' },
+  bypass: { kind: 'info', text: () => 'degraded path engaged · order buffered, customer told the truth' },
+  rejoin: { kind: 'ok', text: () => 'rejoined the primary path' },
+  complete: { kind: 'done', text: () => 'order acknowledged end to end' }
 }
 
-export function SystemsExperience() {
-  const [activeLayer, setActiveLayer] = useState<LayerId>('interface')
-  const [activePath, setActivePath] = useState<PathId>('product')
-  const layer = layers[activeLayer]
-  const path = paths[activePath]
+/* ------------------------------------------------------- static cross-section */
 
-  const selectSceneNode = useCallback((id: string) => {
-    const nextLayer = sceneNodeToLayer[id]
-    if (nextLayer) setActiveLayer(nextLayer)
+const PLAN_W = 1200
+const PLAN_H = 460
+
+function CrossSection({
+  activeId,
+  faults,
+  onSelect
+}: {
+  activeId: string
+  faults: Record<string, boolean>
+  onSelect: (id: string) => void
+}) {
+  const boxW = 190
+  const gap = (PLAN_W - 80 - boxW * stages.length) / (stages.length - 1)
+  return (
+    <div className={styles.planWrap}>
+      <svg
+        className={styles.plan}
+        viewBox={`0 0 ${PLAN_W} ${PLAN_H}`}
+        role="img"
+        aria-label="Cross-section of the request path: edge, service, data, runtime, feedback."
+      >
+        <line x1="10" y1={PLAN_H / 2} x2={PLAN_W - 10} y2={PLAN_H / 2} className={styles.planBus} />
+        {stages.map((stage, index) => {
+          const x = 40 + index * (boxW + gap)
+          const faulted = faults[stage.id]
+          const active = stage.id === activeId
+          return (
+            <g
+              key={stage.id}
+              className={
+                faulted
+                  ? styles.planStageFault
+                  : active
+                    ? styles.planStageActive
+                    : styles.planStage
+              }
+              onClick={() => onSelect(stage.id)}
+            >
+              <rect x={x} y={PLAN_H / 2 - 110} width={boxW} height="220" rx="6" />
+              <text x={x + 18} y={PLAN_H / 2 - 66} className={styles.planCode}>
+                {stage.code}
+              </text>
+              <text x={x + 18} y={PLAN_H / 2 - 22}>
+                {stage.name.toUpperCase()}
+              </text>
+              <text x={x + 18} y={PLAN_H / 2 + 22} className={styles.planTool}>
+                {stage.tools[0].toUpperCase()}
+              </text>
+              <text x={x + 18} y={PLAN_H / 2 + 52} className={styles.planTool}>
+                {(stage.tools[1] ?? '').toUpperCase()}
+              </text>
+              {faulted && (
+                <text x={x + 18} y={PLAN_H / 2 + 92} className={styles.planFaultTag}>
+                  FAULT ARMED
+                </text>
+              )}
+            </g>
+          )
+        })}
+      </svg>
+    </div>
+  )
+}
+
+/* -------------------------------------------------------------------- page */
+
+export function SystemsExperience() {
+  const theme = useMachineTheme()
+  const reduced = usePrefersReducedMotion()
+  const webgl = useWebglSupported()
+  const live = webgl === true && !reduced
+
+  const [running, setRunning] = useState(true)
+  const [speedIndex, setSpeedIndex] = useState(1)
+  const [explode, setExplode] = useState(0)
+  const [faults, setFaults] = useState<Record<string, boolean>>({})
+  const [activeId, setActiveId] = useState('service')
+  const [hoverId, setHoverId] = useState<string | null>(null)
+  const [stepToken, setStepToken] = useState(0)
+  const [log, setLog] = useState<LogLine[]>([])
+  const logId = useRef(0)
+
+  const stage = stagesById[activeId]
+  const faultCount = Object.values(faults).filter(Boolean).length
+
+  const pushEvent = useCallback(
+    (event: MachineEvent, stageId: string, at: number) => {
+      const copy = EVENT_COPY[event]
+      const name = stagesById[stageId]?.name.toUpperCase() ?? 'BUS'
+      const text =
+        event === 'fault'
+          ? `${name} · ${stagesById[stageId]?.faultLine ?? 'fault'}`
+          : copy.text(name)
+      logId.current += 1
+      const line: LogLine = {
+        id: logId.current,
+        kind: copy.kind,
+        stage: name,
+        text,
+        at: Math.round(at)
+      }
+      setLog((current) => [line, ...current].slice(0, 12))
+    },
+    []
+  )
+
+  const toggleFault = useCallback((id: string) => {
+    setFaults((current) => ({ ...current, [id]: !current[id] }))
+    setActiveId(id)
   }, [])
 
-  const choosePath = (id: PathId) => {
-    setActivePath(id)
-    setActiveLayer(paths[id].sequence[0])
-  }
+  useEffect(() => {
+    if (live) return
+    setLog([])
+  }, [live])
 
   return (
     <main className={styles.page}>
-      <section className={styles.hero} aria-labelledby="systems-title">
-        <SpaceScene mode="systems" onNodeSelect={selectSceneNode} />
-        <div className={styles.heroShade} aria-hidden="true" />
-        <div className={styles.heroHeading}>
-          <p className={styles.eyebrow}>Systems atlas · 003</p>
-          <h1 id="systems-title">Breadth is useful when the parts connect.</h1>
-          <p>
-            My toolkit spans interfaces, services, data, cloud, delivery, and AI
-            exploration. This atlas shows the handoffs between them—not just the
-            names of the tools.
-          </p>
-        </div>
+      <section className={styles.bench} aria-labelledby="systems-title">
+        <header className={styles.benchHead}>
+          <div>
+            <p className={styles.eyebrow}>SYS-1 · order path · cutaway</p>
+            <h1 id="systems-title">Break it on purpose.</h1>
+            <p className={styles.lede}>
+              This is the shape of the system I spent two years inside: a
+              third-party delivery order entering Chick-fil-A’s platform from
+              DoorDash, UberEats or Grubhub and coming back out acknowledged.
+              Run it, slow it down, pull it apart, or kill a stage and watch what
+              the rest of the machine does about it.
+            </p>
+          </div>
+          <ul className={styles.statusStack} aria-label="Machine status">
+            <li>
+              <i className={running ? styles.ledOk : styles.ledAmber} aria-hidden="true" />
+              {running ? 'RUNNING' : 'HELD'}
+            </li>
+            <li>
+              <i className={styles.ledSignal} aria-hidden="true" />
+              {SPEEDS[speedIndex]}× RATE
+            </li>
+            <li>
+              <i className={faultCount ? styles.ledFault : styles.ledOk} aria-hidden="true" />
+              {faultCount} FAULT{faultCount === 1 ? '' : 'S'} ARMED
+            </li>
+          </ul>
+        </header>
 
-        <div className={styles.pathExplorer}>
-          <div className={styles.pathHeader}>
-            <div>
-              <span className={styles.pathKicker}>Select an outcome path</span>
-              <div
-                className={styles.pathTabs}
-                role="group"
-                aria-label="Engineering outcome paths"
+        <div className={styles.instrument}>
+          <div className={styles.viewport}>
+            <div className={styles.viewportInner}>
+              {live ? (
+                <CutawayScene
+                  theme={theme}
+                  running={running}
+                  speed={SPEEDS[speedIndex]}
+                  explode={explode}
+                  faults={faults}
+                  activeId={activeId}
+                  stepToken={stepToken}
+                  onSelect={setActiveId}
+                  onHover={setHoverId}
+                  onEvent={pushEvent}
+                />
+              ) : (
+                <CrossSection activeId={activeId} faults={faults} onSelect={setActiveId} />
+              )}
+            </div>
+            <div className={styles.viewportRail}>
+              <span className={styles.railTag}>
+                {live ? 'DRAG TO TILT · CLICK A MODULE' : 'STATIC CROSS-SECTION'}
+              </span>
+              <span className={styles.railTag}>
+                {hoverId
+                  ? `HOVER ${stagesById[hoverId].code} · ${stagesById[hoverId].name}`
+                  : `SELECTED ${stage.code} · ${stage.name}`}
+              </span>
+            </div>
+          </div>
+
+          <div className={styles.transport}>
+            <div className={styles.transportRow}>
+              <button
+                type="button"
+                className={running ? styles.runButtonActive : styles.runButton}
+                onClick={() => setRunning((value) => !value)}
+                aria-pressed={running}
+                disabled={!live}
               >
-                {Object.entries(paths).map(([id, item]) => (
+                <i aria-hidden="true" />
+                {running ? 'Pause' : 'Run'}
+              </button>
+              <button
+                type="button"
+                className={styles.stepButton}
+                onClick={() => {
+                  setRunning(false)
+                  setStepToken((token) => token + 1)
+                }}
+                disabled={!live}
+              >
+                Step ▸
+              </button>
+
+              <div className={styles.speedGroup} role="group" aria-label="Playback rate">
+                {SPEEDS.map((value, index) => (
                   <button
-                    key={id}
+                    key={value}
                     type="button"
-                    className={
-                      activePath === id ? styles.pathTabActive : styles.pathTab
-                    }
-                    onClick={() => choosePath(id as PathId)}
-                    aria-pressed={activePath === id}
+                    className={index === speedIndex ? styles.speedActive : styles.speed}
+                    aria-pressed={index === speedIndex}
+                    onClick={() => setSpeedIndex(index)}
+                    disabled={!live}
                   >
-                    {item.label}
+                    {value}×
                   </button>
                 ))}
               </div>
+
+              <label className={styles.slider}>
+                <span>Cutaway</span>
+                <input
+                  type="range"
+                  min={0}
+                  max={100}
+                  value={Math.round(explode * 100)}
+                  onChange={(event) => setExplode(Number(event.target.value) / 100)}
+                  disabled={!live}
+                />
+              </label>
             </div>
-            <p>{path.description}</p>
-          </div>
 
-          <div
-            className={styles.signalPath}
-            aria-label={`${path.label} capability sequence`}
-          >
-            {Object.entries(layers).map(([id, item]) => {
-              const layerId = id as LayerId
-              const sequenceIndex = path.sequence.indexOf(layerId)
-              const isInPath = sequenceIndex >= 0
-              const isActive = activeLayer === layerId
-
-              return (
+            <div className={styles.faultRow}>
+              <p className={styles.transportLabel}>Fault injection</p>
+              <div className={styles.faultGrid} role="group" aria-label="Inject a fault">
+                {stages.map((item) => (
+                  <button
+                    key={item.id}
+                    type="button"
+                    className={faults[item.id] ? styles.faultOn : styles.fault}
+                    aria-pressed={Boolean(faults[item.id])}
+                    onClick={() => toggleFault(item.id)}
+                    onMouseEnter={() => setHoverId(item.id)}
+                    onMouseLeave={() => setHoverId(null)}
+                  >
+                    <i aria-hidden="true" />
+                    {item.code} {item.name}
+                  </button>
+                ))}
                 <button
-                  key={id}
                   type="button"
-                  className={`${styles.layerNode} ${isInPath ? styles.layerNodeInPath : ''} ${isActive ? styles.layerNodeActive : ''}`}
-                  onClick={() => setActiveLayer(layerId)}
-                  aria-pressed={isActive}
+                  className={styles.clearButton}
+                  onClick={() => setFaults({})}
+                  disabled={faultCount === 0}
                 >
-                  <span className={styles.layerOrder}>
-                    {isInPath
-                      ? String(sequenceIndex + 1).padStart(2, '0')
-                      : '—'}
-                  </span>
-                  <strong>{item.short}</strong>
-                  <small>{item.tools}</small>
+                  Clear
                 </button>
-              )
-            })}
+              </div>
+            </div>
           </div>
 
-          <article
-            className={styles.activeLayer}
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            <div className={styles.activeLayerHeading}>
-              <span>{layer.number}</span>
-              <div>
-                <p>Active capability</p>
-                <h2>{layer.title}</h2>
+          <div className={styles.logColumn}>
+            <div className={styles.scope}>
+              <div className={styles.scopeHead}>
+                <span className={styles.scopeChannel}>
+                  <i className={styles.ledSignal} aria-hidden="true" />
+                  EVENT LOG
+                </span>
+                <span className={styles.scopeHeadRight}>
+                  {live ? 'STREAMING' : 'STATIC'}
+                </span>
               </div>
-              <strong>{layer.tools}</strong>
+              <ol className={styles.log} aria-live="polite">
+                {log.length === 0 && (
+                  <li className={styles.logIdle}>
+                    {live
+                      ? 'waiting for the first request…'
+                      : 'live trace disabled — the written incident walkthrough is below.'}
+                  </li>
+                )}
+                {log.map((line) => (
+                  <li key={line.id} className={styles[`log_${line.kind}`]}>
+                    <span className={styles.logTime}>t+{line.at}ms</span>
+                    <span className={styles.logKind}>{line.kind.toUpperCase()}</span>
+                    <span>{line.text}</span>
+                  </li>
+                ))}
+              </ol>
             </div>
-            <div className={styles.activeLayerBody}>
-              <p>{layer.role}</p>
-              <dl>
-                <div>
-                  <dt>Input</dt>
-                  <dd>{layer.inputs}</dd>
+
+            <div className={styles.scope}>
+              <div className={styles.scopeHead}>
+                <span className={styles.scopeChannel}>
+                  <i className={styles.ledSignal} aria-hidden="true" />
+                  STAGE {stage.code}
+                </span>
+                <span className={styles.scopeHeadRight}>
+                  {faults[stage.id] ? 'FAULT ARMED' : 'HEALTHY'}
+                </span>
+              </div>
+              <div className={styles.readout}>
+                <p className={styles.readoutRole}>{stage.strap}</p>
+                <h2 className={styles.readoutTitle}>{stage.name}</h2>
+                <p className={styles.readoutBody}>{stage.what}</p>
+                <p className={styles.blockLabel}>The decision that shaped it</p>
+                <p className={styles.readoutBody}>{stage.decision}</p>
+                <div className={styles.faultBlock}>
+                  <p className={styles.faultTitle}>If this fails</p>
+                  <p className={styles.faultLine}>{stage.faultLine}</p>
+                  <p className={styles.readoutBody}>{stage.faultDetail}</p>
                 </div>
-                <div>
-                  <dt>Output</dt>
-                  <dd>{layer.output}</dd>
-                </div>
-              </dl>
-              <blockquote>{layer.question}</blockquote>
+                <dl className={styles.measured}>
+                  {stage.evidence.map((row) => (
+                    <div key={row.label}>
+                      <dt>{row.label}</dt>
+                      <dd>{row.value}</dd>
+                    </div>
+                  ))}
+                </dl>
+                <ul className={styles.chips} aria-label={`${stage.name} tools`}>
+                  {stage.tools.map((tool) => (
+                    <li key={tool}>{tool}</li>
+                  ))}
+                </ul>
+              </div>
             </div>
-          </article>
+          </div>
         </div>
       </section>
 
-      <section className={styles.index} aria-labelledby="index-title">
-        <div className={styles.sectionHeading}>
-          <div>
-            <p className={styles.eyebrow}>Capability index · plain text</p>
-            <h2 id="index-title">The whole system, one layer at a time.</h2>
-          </div>
+      <section className={styles.bom} aria-labelledby="path-title">
+        <div className={styles.sectionHead}>
+          <p className={styles.eyebrow}>Written walkthrough</p>
+          <h2 id="path-title">The same path, in plain text.</h2>
           <p>
-            No single tool is the point. The value is being able to follow a
-            product decision down through implementation and operations—and
-            bring what production teaches back to the next decision.
+            Every stage of the machine, the decision that shaped it, and what
+            happens when it breaks — readable without a canvas, a mouse or a GPU.
           </p>
         </div>
 
-        <div className={styles.indexGrid}>
-          {Object.entries(layers).map(([id, item]) => (
-            <article key={id} className={styles.indexCard}>
-              <div className={styles.indexTopline}>
-                <span>{item.number}</span>
-                <span>{item.tools}</span>
-              </div>
-              <div>
-                <h3>{item.title}</h3>
-                <p>{item.role}</p>
-              </div>
-              <dl>
-                <div>
-                  <dt>System question</dt>
-                  <dd>{item.question}</dd>
+        <ol className={styles.bomList}>
+          {stages.map((item) => (
+            <li key={item.id} id={`stage-${item.id}`}>
+              <article className={styles.bomRow}>
+                <div className={styles.bomIdent}>
+                  <span className={styles.bomDesignator}>STAGE {item.code}</span>
+                  <h3>{item.name}</h3>
+                  <p className={styles.bomRole}>{item.strap}</p>
                 </div>
-              </dl>
-            </article>
+                <div className={styles.bomText}>
+                  <p className={styles.bomHead}>{item.what}</p>
+                  <p>{item.decision}</p>
+                  <p className={styles.bomFault}>
+                    <strong>Failure mode — {item.faultLine}.</strong>{' '}
+                    {item.faultDetail}
+                  </p>
+                  <dl className={styles.bomMetrics}>
+                    {item.evidence.map((row) => (
+                      <div key={row.label}>
+                        <dt>{row.label}</dt>
+                        <dd>{row.value}</dd>
+                      </div>
+                    ))}
+                  </dl>
+                  <ul className={styles.chips}>
+                    {item.tools.map((tool) => (
+                      <li key={tool}>{tool}</li>
+                    ))}
+                  </ul>
+                </div>
+              </article>
+            </li>
           ))}
-        </div>
-      </section>
-
-      <section className={styles.model} aria-labelledby="model-title">
-        <div className={styles.modelIntro}>
-          <p className={styles.eyebrow}>Systems model</p>
-          <h2 id="model-title">A loop, not a stack.</h2>
-          <p>
-            Product intent moves toward production. Runtime evidence moves back
-            toward the product. Good engineering keeps both directions visible.
-          </p>
-        </div>
-        <ol className={styles.loop}>
-          <li>
-            <span>01</span>
-            <strong>Frame</strong>
-            <small>Understand the product and operating context.</small>
-          </li>
-          <li>
-            <span>02</span>
-            <strong>Connect</strong>
-            <small>Design the boundaries and handoffs between layers.</small>
-          </li>
-          <li>
-            <span>03</span>
-            <strong>Deliver</strong>
-            <small>Make change safe enough to move with confidence.</small>
-          </li>
-          <li>
-            <span>04</span>
-            <strong>Learn</strong>
-            <small>Use production feedback to improve the next decision.</small>
-          </li>
         </ol>
       </section>
 
-      <section className={styles.next} aria-labelledby="systems-next-title">
-        <div>
-          <p className={styles.eyebrow}>Context behind the toolkit</p>
-          <h2 id="systems-next-title">See where the range came from.</h2>
-        </div>
-        <div>
-          <p>
-            The career map connects these capabilities to consulting, embedded
-            client work, and an approach to engineering leadership.
+      <section className={styles.spec} aria-labelledby="close-title">
+        <div className={styles.specInner}>
+          <div className={styles.sectionHead}>
+            <p className={styles.eyebrow}>Operator</p>
+            <h2 id="close-title">Built by the person on call for it.</h2>
+          </div>
+          <p className={styles.closing}>
+            Project engineering lead on Chick-fil-A’s third-party delivery
+            integrations from 2020 to 2022, through the Covid demand curve that
+            took daily delivery revenue from under $1M to $5M. Before that,
+            backend lead on Apple’s chatbot while it went from 1M to 15M users
+            with 100% uptime. Both through one consulting firm: Big Nerd Ranch.
           </p>
-          <Link href="/career">
-            Explore the career map <span aria-hidden="true">→</span>
-          </Link>
+          <div className={styles.specActions}>
+            <Link className={styles.primaryAction} href="/career">
+              See the rack <span aria-hidden="true">→</span>
+            </Link>
+            <Link className={styles.secondaryAction} href="mailto:devjbull@gmail.com">
+              devjbull@gmail.com <span aria-hidden="true">↗</span>
+            </Link>
+            <Link
+              className={styles.secondaryAction}
+              href="https://www.linkedin.com/in/bulldevon"
+              target="_blank"
+              rel="noreferrer"
+            >
+              LinkedIn <span aria-hidden="true">↗</span>
+            </Link>
+          </div>
         </div>
       </section>
     </main>

--- a/app/systems/systems-experience.tsx
+++ b/app/systems/systems-experience.tsx
@@ -13,17 +13,39 @@ import {
 import styles from './systems.module.css'
 
 const CutawayScene = dynamic(
-  () => import('@/components/machine/cutaway-scene').then((mod) => mod.CutawayScene),
-  { ssr: false, loading: () => <div className={styles.sceneLoading} aria-hidden="true" /> }
+  () =>
+    import('@/components/machine/cutaway-scene').then(
+      (mod) => mod.CutawayScene
+    ),
+  {
+    ssr: false,
+    loading: () => <div className={styles.sceneLoading} aria-hidden="true" />
+  }
 )
 
-type LogLine = { id: number; kind: string; stage: string; text: string; at: number }
+type LogLine = {
+  id: number
+  kind: string
+  stage: string
+  text: string
+  at: number
+}
 
-const EVENT_COPY: Record<MachineEvent, { kind: string; text: (stage: string) => string }> = {
+const EVENT_COPY: Record<
+  MachineEvent,
+  { kind: string; text: (stage: string) => string }
+> = {
   enter: { kind: 'ok', text: (stage) => `${stage} accepted the request` },
   fault: { kind: 'err', text: (stage) => `${stage} fault injected` },
-  breaker: { kind: 'warn', text: () => 'retries exhausted · circuit breaker OPEN' },
-  bypass: { kind: 'info', text: () => 'degraded path engaged · order buffered, customer told the truth' },
+  breaker: {
+    kind: 'warn',
+    text: () => 'retries exhausted · circuit breaker OPEN'
+  },
+  bypass: {
+    kind: 'info',
+    text: () =>
+      'degraded path engaged · order buffered, customer told the truth'
+  },
   rejoin: { kind: 'ok', text: () => 'rejoined the primary path' },
   complete: { kind: 'done', text: () => 'order acknowledged end to end' }
 }
@@ -52,7 +74,13 @@ function CrossSection({
         role="img"
         aria-label="Cross-section of the request path: edge, service, data, runtime, feedback."
       >
-        <line x1="10" y1={PLAN_H / 2} x2={PLAN_W - 10} y2={PLAN_H / 2} className={styles.planBus} />
+        <line
+          x1="10"
+          y1={PLAN_H / 2}
+          x2={PLAN_W - 10}
+          y2={PLAN_H / 2}
+          className={styles.planBus}
+        />
         {stages.map((stage, index) => {
           const x = 40 + index * (boxW + gap)
           const faulted = faults[stage.id]
@@ -69,7 +97,13 @@ function CrossSection({
               }
               onClick={() => onSelect(stage.id)}
             >
-              <rect x={x} y={PLAN_H / 2 - 110} width={boxW} height="220" rx="6" />
+              <rect
+                x={x}
+                y={PLAN_H / 2 - 110}
+                width={boxW}
+                height="220"
+                rx="6"
+              />
               <text x={x + 18} y={PLAN_H / 2 - 66} className={styles.planCode}>
                 {stage.code}
               </text>
@@ -83,7 +117,11 @@ function CrossSection({
                 {(stage.tools[1] ?? '').toUpperCase()}
               </text>
               {faulted && (
-                <text x={x + 18} y={PLAN_H / 2 + 92} className={styles.planFaultTag}>
+                <text
+                  x={x + 18}
+                  y={PLAN_H / 2 + 92}
+                  className={styles.planFaultTag}
+                >
                   FAULT ARMED
                 </text>
               )}
@@ -158,13 +196,16 @@ export function SystemsExperience() {
               This is the shape of the system I spent two years inside: a
               third-party delivery order entering Chick-fil-A’s platform from
               DoorDash, UberEats or Grubhub and coming back out acknowledged.
-              Run it, slow it down, pull it apart, or kill a stage and watch what
-              the rest of the machine does about it.
+              Run it, slow it down, pull it apart, or kill a stage and watch
+              what the rest of the machine does about it.
             </p>
           </div>
           <ul className={styles.statusStack} aria-label="Machine status">
             <li>
-              <i className={running ? styles.ledOk : styles.ledAmber} aria-hidden="true" />
+              <i
+                className={running ? styles.ledOk : styles.ledAmber}
+                aria-hidden="true"
+              />
               {running ? 'RUNNING' : 'HELD'}
             </li>
             <li>
@@ -172,121 +213,148 @@ export function SystemsExperience() {
               {SPEEDS[speedIndex]}× RATE
             </li>
             <li>
-              <i className={faultCount ? styles.ledFault : styles.ledOk} aria-hidden="true" />
+              <i
+                className={faultCount ? styles.ledFault : styles.ledOk}
+                aria-hidden="true"
+              />
               {faultCount} FAULT{faultCount === 1 ? '' : 'S'} ARMED
             </li>
           </ul>
         </header>
 
         <div className={styles.instrument}>
-          <div className={styles.viewport}>
-            <div className={styles.viewportInner}>
-              {live ? (
-                <CutawayScene
-                  theme={theme}
-                  running={running}
-                  speed={SPEEDS[speedIndex]}
-                  explode={explode}
-                  faults={faults}
-                  activeId={activeId}
-                  stepToken={stepToken}
-                  onSelect={setActiveId}
-                  onHover={setHoverId}
-                  onEvent={pushEvent}
-                />
-              ) : (
-                <CrossSection activeId={activeId} faults={faults} onSelect={setActiveId} />
-              )}
-            </div>
-            <div className={styles.viewportRail}>
-              <span className={styles.railTag}>
-                {live ? 'DRAG TO TILT · CLICK A MODULE' : 'STATIC CROSS-SECTION'}
-              </span>
-              <span className={styles.railTag}>
-                {hoverId
-                  ? `HOVER ${stagesById[hoverId].code} · ${stagesById[hoverId].name}`
-                  : `SELECTED ${stage.code} · ${stage.name}`}
-              </span>
-            </div>
-          </div>
-
-          <div className={styles.transport}>
-            <div className={styles.transportRow}>
-              <button
-                type="button"
-                className={running ? styles.runButtonActive : styles.runButton}
-                onClick={() => setRunning((value) => !value)}
-                aria-pressed={running}
-                disabled={!live}
-              >
-                <i aria-hidden="true" />
-                {running ? 'Pause' : 'Run'}
-              </button>
-              <button
-                type="button"
-                className={styles.stepButton}
-                onClick={() => {
-                  setRunning(false)
-                  setStepToken((token) => token + 1)
-                }}
-                disabled={!live}
-              >
-                Step ▸
-              </button>
-
-              <div className={styles.speedGroup} role="group" aria-label="Playback rate">
-                {SPEEDS.map((value, index) => (
-                  <button
-                    key={value}
-                    type="button"
-                    className={index === speedIndex ? styles.speedActive : styles.speed}
-                    aria-pressed={index === speedIndex}
-                    onClick={() => setSpeedIndex(index)}
-                    disabled={!live}
-                  >
-                    {value}×
-                  </button>
-                ))}
+          <div className={styles.column}>
+            <div className={styles.viewport}>
+              <div className={styles.viewportInner}>
+                {live ? (
+                  <CutawayScene
+                    theme={theme}
+                    running={running}
+                    speed={SPEEDS[speedIndex]}
+                    explode={explode}
+                    faults={faults}
+                    activeId={activeId}
+                    stepToken={stepToken}
+                    onSelect={setActiveId}
+                    onHover={setHoverId}
+                    onEvent={pushEvent}
+                  />
+                ) : (
+                  <CrossSection
+                    activeId={activeId}
+                    faults={faults}
+                    onSelect={setActiveId}
+                  />
+                )}
               </div>
-
-              <label className={styles.slider}>
-                <span>Cutaway</span>
-                <input
-                  type="range"
-                  min={0}
-                  max={100}
-                  value={Math.round(explode * 100)}
-                  onChange={(event) => setExplode(Number(event.target.value) / 100)}
-                  disabled={!live}
-                />
-              </label>
+              <div className={styles.viewportRail}>
+                <span className={styles.railTag}>
+                  {live
+                    ? 'DRAG TO TILT · CLICK A MODULE'
+                    : 'STATIC CROSS-SECTION'}
+                </span>
+                <span className={styles.railTag}>
+                  {hoverId
+                    ? `HOVER ${stagesById[hoverId].code} · ${stagesById[hoverId].name}`
+                    : `SELECTED ${stage.code} · ${stage.name}`}
+                </span>
+              </div>
             </div>
 
-            <div className={styles.faultRow}>
-              <p className={styles.transportLabel}>Fault injection</p>
-              <div className={styles.faultGrid} role="group" aria-label="Inject a fault">
-                {stages.map((item) => (
-                  <button
-                    key={item.id}
-                    type="button"
-                    className={faults[item.id] ? styles.faultOn : styles.fault}
-                    aria-pressed={Boolean(faults[item.id])}
-                    onClick={() => toggleFault(item.id)}
-                    onMouseEnter={() => setHoverId(item.id)}
-                    onMouseLeave={() => setHoverId(null)}
-                  >
-                    <i aria-hidden="true" />
-                    {item.code} {item.name}
-                  </button>
-                ))}
+            <div className={styles.transport}>
+              <div className={styles.transportRow}>
                 <button
                   type="button"
-                  className={styles.clearButton}
-                  onClick={() => setFaults({})}
-                  disabled={faultCount === 0}
+                  className={
+                    running ? styles.runButtonActive : styles.runButton
+                  }
+                  onClick={() => setRunning((value) => !value)}
+                  aria-pressed={running}
+                  disabled={!live}
                 >
-                  Clear
+                  <i aria-hidden="true" />
+                  {running ? 'Pause' : 'Run'}
                 </button>
+                <button
+                  type="button"
+                  className={styles.stepButton}
+                  onClick={() => {
+                    setRunning(false)
+                    setStepToken((token) => token + 1)
+                  }}
+                  disabled={!live}
+                >
+                  Step ▸
+                </button>
+
+                <div
+                  className={styles.speedGroup}
+                  role="group"
+                  aria-label="Playback rate"
+                >
+                  {SPEEDS.map((value, index) => (
+                    <button
+                      key={value}
+                      type="button"
+                      className={
+                        index === speedIndex ? styles.speedActive : styles.speed
+                      }
+                      aria-pressed={index === speedIndex}
+                      onClick={() => setSpeedIndex(index)}
+                      disabled={!live}
+                    >
+                      {value}×
+                    </button>
+                  ))}
+                </div>
+
+                <label className={styles.slider}>
+                  <span>Cutaway</span>
+                  <input
+                    type="range"
+                    min={0}
+                    max={100}
+                    value={Math.round(explode * 100)}
+                    onChange={(event) =>
+                      setExplode(Number(event.target.value) / 100)
+                    }
+                    disabled={!live}
+                  />
+                </label>
+              </div>
+
+              <div className={styles.faultRow}>
+                <p className={styles.transportLabel}>Fault injection</p>
+                <div
+                  className={styles.faultGrid}
+                  role="group"
+                  aria-label="Inject a fault"
+                >
+                  {stages.map((item) => (
+                    <button
+                      key={item.id}
+                      type="button"
+                      className={
+                        faults[item.id] ? styles.faultOn : styles.fault
+                      }
+                      aria-pressed={Boolean(faults[item.id])}
+                      onClick={() => toggleFault(item.id)}
+                      onMouseEnter={() => setHoverId(item.id)}
+                      onMouseLeave={() => setHoverId(null)}
+                    >
+                      <i aria-hidden="true" />
+                      {item.code} {item.name}
+                    </button>
+                  ))}
+                  <button
+                    type="button"
+                    className={styles.clearButton}
+                    onClick={() => setFaults({})}
+                    disabled={faultCount === 0}
+                  >
+                    Clear
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -313,7 +381,9 @@ export function SystemsExperience() {
                 {log.map((line) => (
                   <li key={line.id} className={styles[`log_${line.kind}`]}>
                     <span className={styles.logTime}>t+{line.at}ms</span>
-                    <span className={styles.logKind}>{line.kind.toUpperCase()}</span>
+                    <span className={styles.logKind}>
+                      {line.kind.toUpperCase()}
+                    </span>
                     <span>{line.text}</span>
                   </li>
                 ))}
@@ -366,7 +436,8 @@ export function SystemsExperience() {
           <h2 id="path-title">The same path, in plain text.</h2>
           <p>
             Every stage of the machine, the decision that shaped it, and what
-            happens when it breaks — readable without a canvas, a mouse or a GPU.
+            happens when it breaks — readable without a canvas, a mouse or a
+            GPU.
           </p>
         </div>
 
@@ -375,7 +446,9 @@ export function SystemsExperience() {
             <li key={item.id} id={`stage-${item.id}`}>
               <article className={styles.bomRow}>
                 <div className={styles.bomIdent}>
-                  <span className={styles.bomDesignator}>STAGE {item.code}</span>
+                  <span className={styles.bomDesignator}>
+                    STAGE {item.code}
+                  </span>
                   <h3>{item.name}</h3>
                   <p className={styles.bomRole}>{item.strap}</p>
                 </div>
@@ -423,7 +496,10 @@ export function SystemsExperience() {
             <Link className={styles.primaryAction} href="/career">
               See the rack <span aria-hidden="true">→</span>
             </Link>
-            <Link className={styles.secondaryAction} href="mailto:devjbull@gmail.com">
+            <Link
+              className={styles.secondaryAction}
+              href="mailto:devjbull@gmail.com"
+            >
               devjbull@gmail.com <span aria-hidden="true">↗</span>
             </Link>
             <Link

--- a/app/systems/systems.module.css
+++ b/app/systems/systems.module.css
@@ -18,14 +18,17 @@
   --etch: rgba(180, 230, 220, 0.05);
   color: var(--text);
   background-color: var(--chassis);
-  background-image:
-    repeating-linear-gradient(
-      115deg,
-      var(--etch) 0 1px,
-      transparent 1px 6px
-    );
+  background-image: repeating-linear-gradient(
+    115deg,
+    var(--etch) 0 1px,
+    transparent 1px 6px
+  );
   font-family:
-    ui-sans-serif, system-ui, -apple-system, 'Helvetica Neue', sans-serif;
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    'Helvetica Neue',
+    sans-serif;
 }
 
 :global(html.light) .page {
@@ -50,23 +53,23 @@
 
 @media (prefers-color-scheme: light) {
   :global(html:not(.dark)) .page {
-  --chassis: #eee7db;
-  --panel: #f6f1e7;
-  --panel-2: #e8e0d1;
-  --line: rgba(20, 45, 40, 0.2);
-  --line-strong: rgba(20, 45, 40, 0.42);
-  --text: #16211f;
-  --muted: rgba(22, 33, 31, 0.68);
-  --signal: #0d7a63;
-  --amber: #9a5a15;
-  --fault: #b1372a;
-  --paper: #fbf8f1;
-  --paper-ink: #14201e;
-  --screen: #061210;
-  --screen-ink: #cffbec;
-  --screen-signal: #86f0d2;
-  --shadow: 0 18px 34px rgba(35, 45, 40, 0.16);
-  --etch: rgba(20, 45, 40, 0.06);
+    --chassis: #eee7db;
+    --panel: #f6f1e7;
+    --panel-2: #e8e0d1;
+    --line: rgba(20, 45, 40, 0.2);
+    --line-strong: rgba(20, 45, 40, 0.42);
+    --text: #16211f;
+    --muted: rgba(22, 33, 31, 0.68);
+    --signal: #0d7a63;
+    --amber: #9a5a15;
+    --fault: #b1372a;
+    --paper: #fbf8f1;
+    --paper-ink: #14201e;
+    --screen: #061210;
+    --screen-ink: #cffbec;
+    --screen-signal: #86f0d2;
+    --shadow: 0 18px 34px rgba(35, 45, 40, 0.16);
+    --etch: rgba(20, 45, 40, 0.06);
   }
 }
 
@@ -200,32 +203,47 @@
 .instrument {
   display: grid;
   margin-top: clamp(1.5rem, 3vw, 2.25rem);
-  grid-template-areas:
-    'viewport scope'
-    'channels scope';
   grid-template-columns: minmax(0, 1fr) minmax(21rem, 27rem);
-  grid-template-rows: auto auto;
   align-items: start;
+  gap: clamp(0.9rem, 1.6vw, 1.4rem);
+}
+
+.column {
+  display: grid;
+  min-width: 0;
   gap: clamp(0.9rem, 1.6vw, 1.4rem);
 }
 
 .viewport {
   position: relative;
-  grid-area: viewport;
   padding: 0.75rem;
   border: 1px solid var(--line-strong);
   border-radius: 4px;
   background:
-    radial-gradient(circle at 0.95rem 0.95rem, var(--line-strong) 0 2.5px, transparent 3px),
-    radial-gradient(circle at calc(100% - 0.95rem) 0.95rem, var(--line-strong) 0 2.5px, transparent 3px),
-    radial-gradient(circle at 0.95rem calc(100% - 0.95rem), var(--line-strong) 0 2.5px, transparent 3px),
+    radial-gradient(
+      circle at 0.95rem 0.95rem,
+      var(--line-strong) 0 2.5px,
+      transparent 3px
+    ),
+    radial-gradient(
+      circle at calc(100% - 0.95rem) 0.95rem,
+      var(--line-strong) 0 2.5px,
+      transparent 3px
+    ),
+    radial-gradient(
+      circle at 0.95rem calc(100% - 0.95rem),
+      var(--line-strong) 0 2.5px,
+      transparent 3px
+    ),
     radial-gradient(
       circle at calc(100% - 0.95rem) calc(100% - 0.95rem),
       var(--line-strong) 0 2.5px,
       transparent 3px
     ),
     linear-gradient(180deg, var(--panel-2), var(--panel));
-  box-shadow: var(--shadow), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  box-shadow:
+    var(--shadow),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
 .viewportInner {
@@ -241,7 +259,11 @@
   width: 100%;
   height: 100%;
   background:
-    radial-gradient(circle at 50% 55%, rgba(134, 240, 210, 0.08), transparent 60%),
+    radial-gradient(
+      circle at 50% 55%,
+      rgba(134, 240, 210, 0.08),
+      transparent 60%
+    ),
     var(--chassis);
 }
 
@@ -301,7 +323,6 @@
 /* ---------------------------------------------------------------- channels */
 
 .channels {
-  grid-area: channels;
   padding: 0.85rem 0.9rem 1rem;
   border: 1px solid var(--line);
   border-radius: 4px;
@@ -400,7 +421,6 @@
 /* ------------------------------------------------------------------ scope */
 
 .scopeColumn {
-  grid-area: scope;
   scroll-margin-top: 5rem;
 }
 
@@ -411,7 +431,9 @@
   border: 1px solid var(--line-strong);
   border-radius: 4px;
   background: linear-gradient(180deg, var(--panel-2), var(--panel));
-  box-shadow: var(--shadow), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  box-shadow:
+    var(--shadow),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
 .scopeHead {
@@ -454,7 +476,9 @@
     linear-gradient(rgba(134, 240, 210, 0.11) 1px, transparent 1px),
     linear-gradient(90deg, rgba(134, 240, 210, 0.11) 1px, transparent 1px);
   background-position: center center;
-  background-size: 12.5% 20%, 12.5% 20%;
+  background-size:
+    12.5% 20%,
+    12.5% 20%;
   box-shadow: inset 0 0 2.5rem rgba(0, 0, 0, 0.75);
 }
 
@@ -764,7 +788,8 @@
 /* ------------------------------------------------------------------- spec */
 
 .spec {
-  padding: clamp(3rem, 6vw, 5.5rem) clamp(1rem, 4vw, 3rem) clamp(4rem, 8vw, 7rem);
+  padding: clamp(3rem, 6vw, 5.5rem) clamp(1rem, 4vw, 3rem)
+    clamp(4rem, 8vw, 7rem);
   background:
     repeating-linear-gradient(115deg, var(--etch) 0 1px, transparent 1px 6px),
     var(--chassis);
@@ -933,7 +958,6 @@
 /* ------------------------------------------------------------- transport */
 
 .transport {
-  grid-area: channels;
   padding: 0.9rem 1rem 1rem;
   border: 1px solid var(--line);
   border-radius: 4px;
@@ -1134,7 +1158,6 @@
 
 .logColumn {
   display: grid;
-  grid-area: scope;
   align-content: start;
   gap: clamp(0.9rem, 1.6vw, 1.4rem);
 }
@@ -1283,10 +1306,6 @@
 
 @media (max-width: 1080px) {
   .instrument {
-    grid-template-areas:
-      'viewport'
-      'channels'
-      'scope';
     grid-template-columns: minmax(0, 1fr);
   }
 
@@ -1338,6 +1357,6 @@
 
 @media (max-width: 720px) {
   .viewportInner {
-    aspect-ratio: 4 / 3;
+    aspect-ratio: 1 / 1;
   }
 }

--- a/app/systems/systems.module.css
+++ b/app/systems/systems.module.css
@@ -1,735 +1,1343 @@
 .page {
-  color: #dcebe6;
-  background: #03070a;
-}
-
-.hero {
-  position: relative;
-  min-height: max(60rem, calc(100svh - 4rem));
-  overflow: hidden;
-  isolation: isolate;
-}
-
-.heroShade {
-  position: absolute;
-  inset: 0;
-  z-index: 0;
-  pointer-events: none;
-  background:
-    linear-gradient(90deg, rgba(3, 7, 10, 0.94) 0%, transparent 52%),
-    linear-gradient(
-      0deg,
-      rgba(3, 7, 10, 0.99) 0%,
-      rgba(3, 7, 10, 0.2) 55%,
-      rgba(3, 7, 10, 0.35) 100%
+  --chassis: #070c0e;
+  --panel: #0c1416;
+  --panel-2: #111c1e;
+  --line: rgba(160, 210, 200, 0.16);
+  --line-strong: rgba(160, 210, 200, 0.36);
+  --text: #dfeae7;
+  --muted: rgba(223, 234, 231, 0.62);
+  --signal: #86f0d2;
+  --amber: #f0b45a;
+  --fault: #ff6b57;
+  --paper: #efe9dc;
+  --paper-ink: #14201e;
+  --screen: #050d0c;
+  --screen-ink: #cffbec;
+  --screen-signal: #86f0d2;
+  --shadow: 0 24px 48px rgba(0, 0, 0, 0.5);
+  --etch: rgba(180, 230, 220, 0.05);
+  color: var(--text);
+  background-color: var(--chassis);
+  background-image:
+    repeating-linear-gradient(
+      115deg,
+      var(--etch) 0 1px,
+      transparent 1px 6px
     );
+  font-family:
+    ui-sans-serif, system-ui, -apple-system, 'Helvetica Neue', sans-serif;
 }
 
-.sceneFallback {
-  position: absolute;
-  inset: 0;
-  background:
-    radial-gradient(
-      circle at 70% 30%,
-      rgba(106, 203, 191, 0.2),
-      transparent 4%
-    ),
-    radial-gradient(
-      ellipse at 70% 30%,
-      transparent 18%,
-      rgba(94, 167, 163, 0.12) 18.5%,
-      transparent 19%
-    ),
-    radial-gradient(
-      circle at 22% 76%,
-      rgba(77, 134, 173, 0.15),
-      transparent 26%
-    ),
-    #03070a;
+:global(html.light) .page {
+  --chassis: #eee7db;
+  --panel: #f6f1e7;
+  --panel-2: #e8e0d1;
+  --line: rgba(20, 45, 40, 0.2);
+  --line-strong: rgba(20, 45, 40, 0.42);
+  --text: #16211f;
+  --muted: rgba(22, 33, 31, 0.68);
+  --signal: #0d7a63;
+  --amber: #9a5a15;
+  --fault: #b1372a;
+  --paper: #fbf8f1;
+  --paper-ink: #14201e;
+  --screen: #061210;
+  --screen-ink: #cffbec;
+  --screen-signal: #86f0d2;
+  --shadow: 0 18px 34px rgba(35, 45, 40, 0.16);
+  --etch: rgba(20, 45, 40, 0.06);
+}
+
+@media (prefers-color-scheme: light) {
+  :global(html:not(.dark)) .page {
+  --chassis: #eee7db;
+  --panel: #f6f1e7;
+  --panel-2: #e8e0d1;
+  --line: rgba(20, 45, 40, 0.2);
+  --line-strong: rgba(20, 45, 40, 0.42);
+  --text: #16211f;
+  --muted: rgba(22, 33, 31, 0.68);
+  --signal: #0d7a63;
+  --amber: #9a5a15;
+  --fault: #b1372a;
+  --paper: #fbf8f1;
+  --paper-ink: #14201e;
+  --screen: #061210;
+  --screen-ink: #cffbec;
+  --screen-signal: #86f0d2;
+  --shadow: 0 18px 34px rgba(35, 45, 40, 0.16);
+  --etch: rgba(20, 45, 40, 0.06);
+  }
+}
+
+/* ------------------------------------------------------------------ shell */
+
+.bench {
+  max-width: 96rem;
+  margin: 0 auto;
+  padding: clamp(2rem, 5vw, 4rem) clamp(1rem, 4vw, 3rem) clamp(3rem, 6vw, 5rem);
+}
+
+.benchHead {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: clamp(1.5rem, 4vw, 4rem);
+  padding-bottom: clamp(1.5rem, 3vw, 2.5rem);
+  border-bottom: 1px solid var(--line);
 }
 
 .eyebrow {
-  margin: 0 0 1.15rem;
-  color: #8fc5bd;
+  display: flex;
+  align-items: center;
+  margin: 0 0 1rem;
+  color: var(--signal);
   font:
-    650 0.65rem/1.3 ui-monospace,
+    650 0.66rem/1 ui-monospace,
     SFMono-Regular,
     Menlo,
     monospace;
-  letter-spacing: 0.17em;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
+  gap: 0.75rem;
 }
 
 .eyebrow::before {
-  display: inline-block;
-  width: 2.2rem;
+  width: 2rem;
   height: 1px;
-  margin: 0 0.75rem 0.2rem 0;
   content: '';
   background: currentColor;
 }
 
-.heroHeading {
-  position: absolute;
-  top: clamp(3rem, 7vh, 6rem);
-  left: clamp(1.25rem, 5vw, 5rem);
-  z-index: 2;
-  width: min(45rem, calc(100% - 2.5rem));
-}
-
-.heroHeading h1 {
-  max-width: 13ch;
+.benchHead h1 {
+  max-width: 18ch;
   margin: 0;
-  color: #f3f0e8;
+  color: var(--text);
   font-family: Georgia, 'Times New Roman', serif;
-  font-size: clamp(3.5rem, 6.8vw, 6.8rem);
+  font-size: clamp(2.6rem, 5.6vw, 4.6rem);
   font-weight: 400;
-  line-height: 0.89;
-  letter-spacing: -0.06em;
-  text-wrap: balance;
-  text-shadow: 0 0 3rem #03070a;
+  line-height: 0.88;
+  letter-spacing: -0.045em;
 }
 
-.heroHeading > p:not(.eyebrow) {
-  max-width: 40rem;
-  margin: 1.6rem 0 0;
-  color: rgba(220, 235, 230, 0.66);
-  font-size: clamp(0.95rem, 1.25vw, 1.08rem);
-  line-height: 1.7;
+.lede {
+  max-width: 46rem;
+  margin: 1.4rem 0 0;
+  color: var(--muted);
+  font-size: clamp(0.95rem, 1.1vw, 1.06rem);
+  line-height: 1.72;
 }
 
-.pathExplorer {
-  position: absolute;
-  right: clamp(1.25rem, 4vw, 4rem);
-  bottom: clamp(2rem, 5vh, 4rem);
-  left: clamp(1.25rem, 5vw, 5rem);
-  z-index: 3;
-  padding: 1.2rem;
-  border: 1px solid rgba(191, 228, 220, 0.16);
-  background: rgba(3, 10, 13, 0.79);
-  box-shadow: 0 1.5rem 5rem rgba(0, 0, 0, 0.28);
-  backdrop-filter: blur(18px);
-}
-
-.pathHeader {
+.statusStack {
   display: grid;
-  padding: 0.25rem 0.2rem 1rem;
-  grid-template-columns: 1fr minmax(18rem, 0.5fr);
-  gap: 2rem;
-  border-bottom: 1px solid rgba(191, 228, 220, 0.12);
-  align-items: end;
-}
-
-.pathKicker {
-  display: block;
-  margin-bottom: 0.7rem;
-  color: rgba(220, 235, 230, 0.4);
-  font:
-    600 0.54rem/1 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  letter-spacing: 0.11em;
-  text-transform: uppercase;
-}
-
-.pathTabs {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-}
-
-.pathTab,
-.pathTabActive {
-  min-height: 2.35rem;
-  padding: 0 0.8rem;
-  border: 1px solid rgba(191, 228, 220, 0.14);
-  border-radius: 0.15rem;
-  color: rgba(220, 235, 230, 0.52);
-  background: rgba(7, 20, 23, 0.64);
-  font:
-    650 0.57rem/1 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  cursor: pointer;
-  transition:
-    color 160ms ease,
-    border-color 160ms ease,
-    background 160ms ease;
-}
-
-.pathTab:hover,
-.pathTabActive {
-  border-color: rgba(191, 228, 220, 0.54);
-  color: #eef3ee;
-  background: rgba(44, 105, 100, 0.42);
-}
-
-.pathHeader > p {
   margin: 0;
-  color: rgba(220, 235, 230, 0.54);
-  font-size: 0.78rem;
-  line-height: 1.6;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  background: var(--panel);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  gap: 0.55rem;
+  list-style: none;
 }
 
-.signalPath {
-  position: relative;
-  display: grid;
-  padding: 1rem 0;
-  grid-template-columns: repeat(6, 1fr);
-  gap: 0.45rem;
-}
-
-.signalPath::before {
-  position: absolute;
-  top: 50%;
-  right: 4%;
-  left: 4%;
-  height: 1px;
-  content: '';
-  background: linear-gradient(
-    90deg,
-    transparent,
-    rgba(191, 228, 220, 0.25),
-    transparent
-  );
-}
-
-.layerNode {
-  position: relative;
-  z-index: 1;
+.statusStack li {
   display: flex;
-  min-height: 7.4rem;
-  padding: 0.75rem;
-  border: 1px solid rgba(191, 228, 220, 0.1);
-  flex-direction: column;
-  align-items: flex-start;
-  color: rgba(220, 235, 230, 0.3);
-  background: rgba(4, 12, 15, 0.9);
-  text-align: left;
-  cursor: pointer;
-  transition:
-    color 160ms ease,
-    border-color 160ms ease,
-    background 160ms ease,
-    transform 160ms ease;
-}
-
-.layerNodeInPath {
-  border-color: rgba(142, 200, 190, 0.3);
-  color: rgba(220, 235, 230, 0.72);
-  background: rgba(11, 31, 33, 0.94);
-}
-
-.layerNode:hover,
-.layerNodeActive {
-  border-color: rgba(191, 228, 220, 0.72);
-  color: #f0f3ee;
-  background: rgba(34, 84, 80, 0.84);
-  transform: translateY(-2px);
-}
-
-.layerOrder {
-  color: rgba(191, 228, 220, 0.38);
-  font:
-    600 0.54rem/1 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-}
-
-.layerNode strong {
-  margin-top: auto;
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: 1.25rem;
-  font-weight: 400;
-}
-
-.layerNode small {
-  margin-top: 0.4rem;
-  color: currentColor;
-  font:
-    500 0.5rem/1.35 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  letter-spacing: 0.04em;
-}
-
-.activeLayer {
-  border-top: 1px solid rgba(191, 228, 220, 0.12);
-}
-
-.activeLayerHeading {
-  display: grid;
-  padding: 1rem 0.2rem;
-  grid-template-columns: 2.5rem 1fr auto;
-  gap: 1rem;
   align-items: center;
-}
-
-.activeLayerHeading > span {
-  color: rgba(191, 228, 220, 0.4);
+  color: var(--muted);
   font:
-    600 0.6rem/1 ui-monospace,
+    650 0.6rem/1 ui-monospace,
     SFMono-Regular,
     Menlo,
     monospace;
+  letter-spacing: 0.13em;
+  white-space: nowrap;
+  gap: 0.55rem;
 }
 
-.activeLayerHeading p {
-  margin: 0 0 0.25rem;
-  color: #8fc5bd;
+.ledOk,
+.ledAmber,
+.ledSignal {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  flex: none;
+}
+
+.ledOk {
+  background: #4ad995;
+  box-shadow: 0 0 0.5rem rgba(74, 217, 149, 0.8);
+}
+
+.ledAmber {
+  background: var(--amber);
+  box-shadow: 0 0 0.5rem rgba(240, 180, 90, 0.6);
+}
+
+.ledSignal {
+  background: var(--signal);
+  box-shadow: 0 0 0.55rem var(--signal);
+  animation: blink 2.4s steps(1, end) infinite;
+}
+
+@keyframes blink {
+  0%,
+  62% {
+    opacity: 1;
+  }
+  63%,
+  74% {
+    opacity: 0.25;
+  }
+  75%,
+  100% {
+    opacity: 1;
+  }
+}
+
+/* -------------------------------------------------------------- instrument */
+
+.instrument {
+  display: grid;
+  margin-top: clamp(1.5rem, 3vw, 2.25rem);
+  grid-template-areas:
+    'viewport scope'
+    'channels scope';
+  grid-template-columns: minmax(0, 1fr) minmax(21rem, 27rem);
+  grid-template-rows: auto auto;
+  align-items: start;
+  gap: clamp(0.9rem, 1.6vw, 1.4rem);
+}
+
+.viewport {
+  position: relative;
+  grid-area: viewport;
+  padding: 0.75rem;
+  border: 1px solid var(--line-strong);
+  border-radius: 4px;
+  background:
+    radial-gradient(circle at 0.95rem 0.95rem, var(--line-strong) 0 2.5px, transparent 3px),
+    radial-gradient(circle at calc(100% - 0.95rem) 0.95rem, var(--line-strong) 0 2.5px, transparent 3px),
+    radial-gradient(circle at 0.95rem calc(100% - 0.95rem), var(--line-strong) 0 2.5px, transparent 3px),
+    radial-gradient(
+      circle at calc(100% - 0.95rem) calc(100% - 0.95rem),
+      var(--line-strong) 0 2.5px,
+      transparent 3px
+    ),
+    linear-gradient(180deg, var(--panel-2), var(--panel));
+  box-shadow: var(--shadow), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.viewportInner {
+  position: relative;
+  overflow: hidden;
+  aspect-ratio: 16 / 10;
+  border: 1px solid var(--line);
+  border-radius: 2px;
+  background: var(--chassis);
+}
+
+.sceneLoading {
+  width: 100%;
+  height: 100%;
+  background:
+    radial-gradient(circle at 50% 55%, rgba(134, 240, 210, 0.08), transparent 60%),
+    var(--chassis);
+}
+
+.viewportRail {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.6rem 0.15rem 0.1rem;
+  gap: 1rem;
+}
+
+.railTag {
+  overflow: hidden;
+  color: var(--muted);
   font:
-    600 0.52rem/1 ui-monospace,
+    650 0.58rem/1.2 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.13em;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.coach {
+  position: absolute;
+  right: 1.5rem;
+  bottom: 3rem;
+  display: grid;
+  margin: 0;
+  padding: 0.7rem 0.9rem;
+  border: 1px solid var(--signal);
+  border-radius: 3px;
+  color: var(--text);
+  background: color-mix(in srgb, var(--panel) 88%, transparent);
+  font:
+    650 0.6rem/1.5 ui-monospace,
     SFMono-Regular,
     Menlo,
     monospace;
   letter-spacing: 0.1em;
   text-transform: uppercase;
+  gap: 0.15rem;
+  animation: coachPulse 2.6s ease-in-out infinite;
 }
 
-.activeLayerHeading h2 {
-  margin: 0;
-  color: #eef2ed;
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: clamp(1.7rem, 2.8vw, 2.5rem);
-  font-weight: 400;
-  line-height: 1;
+@keyframes coachPulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(134, 240, 210, 0.4);
+  }
+  50% {
+    box-shadow: 0 0 0 0.5rem rgba(134, 240, 210, 0);
+  }
 }
 
-.activeLayerHeading strong {
-  color: #9dccca;
+/* ---------------------------------------------------------------- channels */
+
+.channels {
+  grid-area: channels;
+  padding: 0.85rem 0.9rem 1rem;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: linear-gradient(180deg, var(--panel-2), var(--panel));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.channelsLabel {
+  margin: 0 0 0.7rem;
+  color: var(--muted);
   font:
-    600 0.57rem/1.4 ui-monospace,
+    650 0.58rem/1 ui-monospace,
     SFMono-Regular,
     Menlo,
     monospace;
-  letter-spacing: 0.07em;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
 }
 
-.activeLayerBody {
+.channelGrid {
   display: grid;
-  padding: 0.9rem 0.2rem 0.2rem;
-  grid-template-columns: 1fr 0.78fr 0.8fr;
-  gap: clamp(1.5rem, 4vw, 4rem);
-  border-top: 1px solid rgba(191, 228, 220, 0.09);
-  align-items: start;
+  grid-template-columns: repeat(auto-fit, minmax(8.5rem, 1fr));
+  gap: 0.5rem;
 }
 
-.activeLayerBody > p,
-.activeLayerBody blockquote {
-  margin: 0;
-  color: rgba(220, 235, 230, 0.62);
-  font-size: 0.78rem;
-  line-height: 1.6;
-}
-
-.activeLayerBody dl {
-  margin: 0;
-}
-
-.activeLayerBody dl > div {
+.channel,
+.channelActive {
   display: grid;
-  margin-bottom: 0.5rem;
-  grid-template-columns: 3.5rem 1fr;
-  gap: 0.6rem;
+  min-height: 3.6rem;
+  padding: 0.55rem 0.6rem;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  color: var(--text);
+  background: linear-gradient(180deg, var(--panel-2), var(--panel));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.07),
+    0 2px 0 rgba(0, 0, 0, 0.35);
+  cursor: pointer;
+  gap: 0.3rem;
+  text-align: left;
+  transition:
+    transform 0.09s ease,
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
 }
 
-.activeLayerBody dt {
-  color: rgba(220, 235, 230, 0.34);
-  font:
-    600 0.5rem/1.5 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  letter-spacing: 0.09em;
-  text-transform: uppercase;
+.channel:hover {
+  border-color: var(--line-strong);
+  transform: translateY(-1px);
 }
 
-.activeLayerBody dd {
-  margin: 0;
-  color: rgba(220, 235, 230, 0.66);
-  font-size: 0.7rem;
-  line-height: 1.5;
+.channelActive {
+  border-color: var(--signal);
+  background: linear-gradient(180deg, var(--panel), var(--panel-2));
+  box-shadow:
+    inset 0 2px 6px rgba(0, 0, 0, 0.45),
+    0 0 0 1px color-mix(in srgb, var(--signal) 35%, transparent);
+  transform: translateY(1px);
 }
 
-.activeLayerBody blockquote {
-  padding-left: 1rem;
-  border-left: 1px solid #8fc5bd;
-  color: #c8ddd7;
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: 0.95rem;
-  font-style: italic;
-}
-
-.index,
-.model,
-.next {
-  padding: clamp(5rem, 9vw, 9rem) clamp(1.25rem, 6vw, 6rem);
-}
-
-.index {
-  color: #142826;
-  background: #e8eee8;
-}
-
-.index .eyebrow {
-  color: #39756f;
-}
-
-.sectionHeading,
-.next {
-  display: grid;
-  grid-template-columns: minmax(0, 0.9fr) minmax(20rem, 0.65fr);
-  gap: clamp(3rem, 8vw, 8rem);
-  align-items: end;
-}
-
-.sectionHeading,
-.indexGrid,
-.modelIntro,
-.loop {
-  width: min(100%, 82rem);
-  margin-right: auto;
-  margin-left: auto;
-}
-
-.sectionHeading h2,
-.modelIntro h2,
-.next h2 {
-  max-width: 13ch;
-  margin: 0;
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: clamp(2.8rem, 5.4vw, 5.5rem);
-  font-weight: 400;
-  line-height: 0.96;
-  letter-spacing: -0.05em;
-  text-wrap: balance;
-}
-
-.sectionHeading > p,
-.modelIntro > p:last-child,
-.next > div:last-child > p {
-  margin: 0;
-  color: rgba(20, 40, 38, 0.66);
-  font-size: clamp(1rem, 1.45vw, 1.15rem);
-  line-height: 1.75;
-}
-
-.indexGrid {
-  display: grid;
-  margin-top: clamp(3.5rem, 7vw, 6.5rem);
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1px;
-  background: rgba(25, 58, 54, 0.18);
-}
-
-.indexCard {
+.channelDesignator {
   display: flex;
-  min-height: 24rem;
-  padding: 1.4rem;
+  align-items: center;
+  color: var(--muted);
+  font:
+    700 0.68rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.12em;
+  gap: 0.4rem;
+}
+
+.channelActive .channelDesignator {
+  color: var(--signal);
+}
+
+.channelDesignator i {
+  width: 0.42rem;
+  height: 0.42rem;
+  border-radius: 50%;
+  background: var(--line-strong);
+}
+
+.channelActive .channelDesignator i {
+  background: var(--signal);
+  box-shadow: 0 0 0.5rem var(--signal);
+}
+
+.channelName {
+  font-size: 0.82rem;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+}
+
+/* ------------------------------------------------------------------ scope */
+
+.scopeColumn {
+  grid-area: scope;
+  scroll-margin-top: 5rem;
+}
+
+.scope {
+  display: flex;
+  height: 100%;
   flex-direction: column;
-  justify-content: space-between;
-  background: #edf1eb;
+  border: 1px solid var(--line-strong);
+  border-radius: 4px;
+  background: linear-gradient(180deg, var(--panel-2), var(--panel));
+  box-shadow: var(--shadow), inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
-.indexTopline {
+.scopeHead {
   display: flex;
+  align-items: center;
   justify-content: space-between;
-  gap: 1rem;
-  color: rgba(20, 40, 38, 0.48);
+  padding: 0.7rem 0.85rem;
+  border-bottom: 1px solid var(--line);
+  color: var(--muted);
   font:
-    600 0.55rem/1.35 ui-monospace,
+    650 0.58rem/1 ui-monospace,
     SFMono-Regular,
     Menlo,
     monospace;
-  letter-spacing: 0.07em;
+  letter-spacing: 0.13em;
+  gap: 0.6rem;
   text-transform: uppercase;
 }
 
-.indexTopline span:last-child {
+.scopeChannel {
+  display: flex;
+  align-items: center;
+  color: var(--signal);
+  gap: 0.45rem;
+}
+
+.scopeHeadRight {
+  color: var(--amber);
+}
+
+.screen {
+  position: relative;
+  overflow: hidden;
+  height: 8.5rem;
+  margin: 0.85rem;
+  border: 1px solid rgba(134, 240, 210, 0.28);
+  border-radius: 2px;
+  background-color: var(--screen);
+  background-image:
+    linear-gradient(rgba(134, 240, 210, 0.11) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(134, 240, 210, 0.11) 1px, transparent 1px);
+  background-position: center center;
+  background-size: 12.5% 20%, 12.5% 20%;
+  box-shadow: inset 0 0 2.5rem rgba(0, 0, 0, 0.75);
+}
+
+.trace {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.trace path {
+  fill: none;
+  stroke: var(--screen-signal);
+  stroke-width: 2px;
+  stroke-linecap: square;
+  filter: drop-shadow(0 0 4px rgba(134, 240, 210, 0.75));
+  animation: sweep 6s linear infinite;
+}
+
+@keyframes sweep {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-100px);
+  }
+}
+
+.screenTagLeft,
+.screenTagRight,
+.screenScale {
+  position: absolute;
+  color: var(--screen-ink);
+  font:
+    650 0.55rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.screenTagLeft {
+  top: 0.5rem;
+  left: 0.6rem;
+}
+
+.screenTagRight {
+  top: 0.5rem;
+  right: 0.6rem;
+  max-width: 60%;
+  opacity: 0.72;
   text-align: right;
 }
 
-.indexCard h3 {
+.screenScale {
+  bottom: 0.5rem;
+  left: 0.6rem;
+  opacity: 0.6;
+}
+
+.readout {
+  padding: 0 1.1rem 1.2rem;
+}
+
+.readoutRole {
   margin: 0;
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: clamp(2rem, 3vw, 3rem);
-  font-weight: 400;
-  line-height: 1;
-  letter-spacing: -0.04em;
-}
-
-.indexCard p {
-  margin: 1rem 0 0;
-  color: rgba(20, 40, 38, 0.64);
-  font-size: 0.88rem;
-  line-height: 1.65;
-}
-
-.indexCard dl,
-.indexCard dd {
-  margin: 0;
-}
-
-.indexCard dl {
-  padding-top: 1rem;
-  border-top: 1px solid rgba(20, 40, 38, 0.12);
-}
-
-.indexCard dt {
-  margin-bottom: 0.45rem;
-  color: #39756f;
+  color: var(--signal);
   font:
-    600 0.54rem/1 ui-monospace,
+    650 0.58rem/1 ui-monospace,
     SFMono-Regular,
     Menlo,
     monospace;
-  letter-spacing: 0.09em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
-.indexCard dd {
-  color: rgba(20, 40, 38, 0.6);
+.readoutTitle {
+  margin: 0.6rem 0 0;
   font-family: Georgia, 'Times New Roman', serif;
-  font-size: 0.92rem;
-  font-style: italic;
+  font-size: clamp(1.6rem, 2.4vw, 2.1rem);
+  font-weight: 400;
+  line-height: 1.05;
+  letter-spacing: -0.03em;
+}
+
+.readoutHead {
+  margin: 0.7rem 0 0;
+  color: var(--text);
+  font-size: 1rem;
   line-height: 1.5;
+  text-wrap: balance;
 }
 
-.model {
-  border-top: 1px solid rgba(191, 228, 220, 0.08);
-  background:
-    radial-gradient(
-      circle at 76% 30%,
-      rgba(53, 118, 112, 0.2),
-      transparent 28%
-    ),
-    #050b0e;
+.readoutBody {
+  margin: 0.75rem 0 0;
+  color: var(--muted);
+  font-size: 0.88rem;
+  line-height: 1.72;
 }
 
-.modelIntro {
+.measured {
   display: grid;
-  grid-template-columns: 0.8fr 1fr 0.75fr;
-  gap: clamp(2rem, 6vw, 6rem);
-  align-items: end;
+  margin: 1.1rem 0 0;
+  border-top: 1px solid var(--line);
 }
 
-.modelIntro .eyebrow {
-  align-self: start;
-}
-
-.modelIntro h2 {
-  max-width: 9ch;
-  color: #f1f0e9;
-}
-
-.modelIntro > p:last-child {
-  color: rgba(220, 235, 230, 0.58);
-}
-
-.loop {
+.measured > div {
   display: grid;
-  margin-top: clamp(3.5rem, 7vw, 6rem);
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--line);
+  grid-template-columns: 7.5rem minmax(0, 1fr);
+  gap: 0.75rem;
+}
+
+.measured dt {
+  color: var(--muted);
+  font:
+    650 0.56rem/1.4 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.measured dd {
+  margin: 0;
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.chips {
+  display: flex;
+  margin: 1rem 0 0;
   padding: 0;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 1px;
-  background: rgba(191, 228, 220, 0.12);
+  flex-wrap: wrap;
+  gap: 0.35rem;
   list-style: none;
 }
 
-.loop li {
-  display: flex;
-  min-height: 16rem;
-  padding: 1.3rem;
-  flex-direction: column;
-  background: rgba(6, 16, 19, 0.96);
-}
-
-.loop span {
-  color: rgba(191, 228, 220, 0.36);
+.chips li {
+  padding: 0.3rem 0.5rem;
+  border: 1px solid var(--line);
+  border-radius: 2px;
+  color: var(--muted);
   font:
     600 0.58rem/1 ui-monospace,
     SFMono-Regular,
     Menlo,
     monospace;
-}
-
-.loop strong {
-  margin-top: auto;
-  color: #edf1eb;
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: clamp(1.8rem, 3vw, 2.7rem);
-  font-weight: 400;
-}
-
-.loop small {
-  margin-top: 0.7rem;
-  color: rgba(220, 235, 230, 0.55);
-  font-size: 0.78rem;
-  line-height: 1.55;
-}
-
-.next {
-  width: min(100%, 94rem);
-  margin: 0 auto;
-}
-
-.next h2 {
-  max-width: 11ch;
-  color: #f1f0e9;
-}
-
-.next > div:last-child > p {
-  color: rgba(220, 235, 230, 0.58);
-}
-
-.next a {
-  display: inline-flex;
-  margin-top: 1.6rem;
-  padding-bottom: 0.35rem;
-  gap: 0.65rem;
-  border-bottom: 1px solid rgba(191, 228, 220, 0.34);
-  color: #bfe4dc;
-  font:
-    650 0.63rem/1 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  letter-spacing: 0.09em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
 
-@media (max-width: 1000px) {
-  .hero {
-    min-height: 77rem;
+.readoutLinks {
+  display: flex;
+  margin-top: 1.1rem;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.linkButton {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.55rem 0.8rem;
+  border: 1px solid var(--signal);
+  border-radius: 2px;
+  color: var(--signal);
+  font:
+    650 0.6rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  gap: 0.45rem;
+}
+
+.linkButton:hover {
+  color: var(--chassis);
+  background: var(--signal);
+}
+
+/* -------------------------------------------------------------------- BOM */
+
+.bom {
+  padding: clamp(3rem, 6vw, 5.5rem) clamp(1rem, 4vw, 3rem);
+  color: var(--paper-ink);
+  background: var(--paper);
+  background-image: repeating-linear-gradient(
+    0deg,
+    rgba(20, 32, 30, 0.045) 0 1px,
+    transparent 1px 2.35rem
+  );
+}
+
+.sectionHead {
+  max-width: 96rem;
+  margin: 0 auto clamp(2rem, 4vw, 3rem);
+}
+
+.bom .eyebrow {
+  color: #1c6f5c;
+}
+
+.sectionHead h2 {
+  max-width: 20ch;
+  margin: 0;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: clamp(2rem, 4.2vw, 3.2rem);
+  font-weight: 400;
+  line-height: 0.95;
+  letter-spacing: -0.035em;
+}
+
+.sectionHead p:not(.eyebrow) {
+  max-width: 44rem;
+  margin: 1rem 0 0;
+  font-size: 0.95rem;
+  line-height: 1.7;
+  opacity: 0.72;
+}
+
+.bomList {
+  max-width: 96rem;
+  margin: 0 auto;
+  padding: 0;
+  border-top: 2px solid rgba(20, 32, 30, 0.45);
+  list-style: none;
+  counter-reset: bom;
+}
+
+.bomList > li {
+  border-bottom: 1px solid rgba(20, 32, 30, 0.22);
+}
+
+.bomRow {
+  display: grid;
+  padding: clamp(1.4rem, 2.5vw, 2rem) 0;
+  grid-template-columns: minmax(0, 15rem) minmax(0, 1fr);
+  gap: clamp(1rem, 4vw, 3.5rem);
+}
+
+.bomDesignator {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid rgba(20, 32, 30, 0.4);
+  color: #14201e;
+  background: rgba(20, 32, 30, 0.06);
+  font:
+    700 0.66rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.12em;
+}
+
+.bomIdent h3 {
+  margin: 0.7rem 0 0;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: 1.5rem;
+  font-weight: 400;
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+}
+
+.bomRole,
+.bomNet {
+  margin: 0.4rem 0 0;
+  font:
+    600 0.58rem/1.5 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  opacity: 0.66;
+}
+
+.bomNet {
+  color: #1c6f5c;
+  opacity: 0.9;
+}
+
+.bomHead {
+  margin: 0;
+  font-size: clamp(1.05rem, 1.6vw, 1.3rem);
+  line-height: 1.35;
+  letter-spacing: -0.015em;
+  text-wrap: balance;
+}
+
+.bomText p:not(.bomHead) {
+  margin: 0.75rem 0 0;
+  max-width: 62ch;
+  font-size: 0.95rem;
+  line-height: 1.72;
+  opacity: 0.78;
+}
+
+.bomText .chips li {
+  border-color: rgba(20, 32, 30, 0.28);
+  color: rgba(20, 32, 30, 0.75);
+}
+
+/* ------------------------------------------------------------------- spec */
+
+.spec {
+  padding: clamp(3rem, 6vw, 5.5rem) clamp(1rem, 4vw, 3rem) clamp(4rem, 8vw, 7rem);
+  background:
+    repeating-linear-gradient(115deg, var(--etch) 0 1px, transparent 1px 6px),
+    var(--chassis);
+}
+
+.specInner {
+  max-width: 96rem;
+  margin: 0 auto;
+}
+
+.spec .sectionHead {
+  margin-bottom: clamp(1.5rem, 3vw, 2.25rem);
+}
+
+.spec .sectionHead h2 {
+  color: var(--text);
+}
+
+.specGrid {
+  display: grid;
+  margin: 0;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: linear-gradient(180deg, var(--panel-2), var(--panel));
+  grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
+}
+
+.specGrid > div {
+  padding: 1rem 1.1rem;
+  border-right: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+}
+
+.specGrid dt {
+  color: var(--signal);
+  font:
+    650 0.56rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.specGrid dd {
+  margin: 0.5rem 0 0;
+  color: var(--text);
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.specActions {
+  display: flex;
+  margin-top: 1.5rem;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.primaryAction,
+.secondaryAction {
+  display: inline-flex;
+  align-items: center;
+  min-height: 3rem;
+  padding: 0 1.1rem;
+  border: 1px solid var(--signal);
+  border-radius: 3px;
+  font:
+    650 0.64rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  gap: 0.5rem;
+}
+
+.primaryAction {
+  color: var(--chassis);
+  background: var(--signal);
+  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.4);
+}
+
+.secondaryAction {
+  color: var(--signal);
+  background: transparent;
+}
+
+.primaryAction:active,
+.secondaryAction:active {
+  transform: translateY(1px);
+}
+
+.secondaryAction:hover {
+  background: color-mix(in srgb, var(--signal) 14%, transparent);
+}
+
+/* ---------------------------------------------------------- cross-section */
+
+.planWrap {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  padding: 0.75rem;
+  background: var(--chassis);
+}
+
+.plan {
+  display: block;
+  width: 100%;
+}
+
+.planBus {
+  stroke: var(--line-strong);
+  stroke-dasharray: 14 10;
+  stroke-width: 4;
+}
+
+.planStage rect,
+.planStageActive rect,
+.planStageFault rect {
+  fill: var(--panel-2);
+  stroke: var(--line-strong);
+  stroke-width: 3;
+  cursor: pointer;
+}
+
+.planStageActive rect {
+  stroke: var(--signal);
+  stroke-width: 5;
+}
+
+.planStageFault rect {
+  stroke: var(--fault);
+  stroke-width: 5;
+}
+
+.planStage text,
+.planStageActive text,
+.planStageFault text {
+  fill: var(--text);
+  font:
+    700 30px ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  pointer-events: none;
+}
+
+.planCode {
+  fill: var(--signal) !important;
+  font-size: 24px !important;
+}
+
+.planTool {
+  font-size: 19px !important;
+  font-weight: 500 !important;
+  opacity: 0.6;
+}
+
+.planFaultTag {
+  fill: var(--fault) !important;
+  font-size: 19px !important;
+}
+
+/* ------------------------------------------------------------- transport */
+
+.transport {
+  grid-area: channels;
+  padding: 0.9rem 1rem 1rem;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: linear-gradient(180deg, var(--panel-2), var(--panel));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.transportRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.transportLabel {
+  margin: 0 0 0.55rem;
+  color: var(--muted);
+  font:
+    650 0.56rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.runButton,
+.runButtonActive,
+.stepButton,
+.clearButton {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.9rem;
+  padding: 0 1rem;
+  border: 1px solid var(--line-strong);
+  border-radius: 3px;
+  color: var(--text);
+  background: linear-gradient(180deg, var(--panel-2), var(--panel));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 2px 0 rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+  font:
+    650 0.66rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  gap: 0.5rem;
+}
+
+.runButton i,
+.runButtonActive i {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--line-strong);
+}
+
+.runButtonActive {
+  border-color: var(--signal);
+  color: var(--signal);
+}
+
+.runButtonActive i {
+  background: var(--signal);
+  box-shadow: 0 0 0.6rem var(--signal);
+}
+
+.runButton:active,
+.runButtonActive:active,
+.stepButton:active {
+  box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.5);
+  transform: translateY(1px);
+}
+
+.clearButton:disabled,
+.runButton:disabled,
+.stepButton:disabled,
+.speed:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.speedGroup {
+  display: inline-flex;
+  overflow: hidden;
+  border: 1px solid var(--line-strong);
+  border-radius: 3px;
+}
+
+.speed,
+.speedActive {
+  min-width: 3rem;
+  min-height: 2.9rem;
+  border: 0;
+  border-right: 1px solid var(--line);
+  color: var(--muted);
+  background: var(--panel);
+  cursor: pointer;
+  font:
+    650 0.64rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+}
+
+.speedActive {
+  color: var(--chassis);
+  background: var(--signal);
+}
+
+.slider {
+  display: inline-flex;
+  align-items: center;
+  color: var(--muted);
+  font:
+    650 0.58rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  gap: 0.6rem;
+}
+
+.slider input {
+  width: 9rem;
+  accent-color: var(--signal);
+}
+
+.faultRow {
+  margin-top: 1rem;
+  padding-top: 0.9rem;
+  border-top: 1px solid var(--line);
+}
+
+.faultGrid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.fault,
+.faultOn {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.7rem;
+  padding: 0 0.75rem;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  color: var(--text);
+  background: linear-gradient(180deg, var(--panel-2), var(--panel));
+  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.35);
+  cursor: pointer;
+  font:
+    650 0.6rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  gap: 0.45rem;
+}
+
+.fault i,
+.faultOn i {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--line-strong);
+}
+
+.faultOn {
+  border-color: var(--fault);
+  color: var(--fault);
+  box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.5);
+  transform: translateY(1px);
+}
+
+.faultOn i {
+  background: var(--fault);
+  box-shadow: 0 0 0.6rem var(--fault);
+}
+
+.ledFault {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--fault);
+  box-shadow: 0 0 0.55rem var(--fault);
+  flex: none;
+}
+
+/* -------------------------------------------------------------- event log */
+
+.logColumn {
+  display: grid;
+  grid-area: scope;
+  align-content: start;
+  gap: clamp(0.9rem, 1.6vw, 1.4rem);
+}
+
+.log {
+  margin: 0;
+  padding: 0.6rem 0.85rem 0.9rem;
+  min-height: 13rem;
+  background: var(--screen);
+  list-style: none;
+}
+
+.log li {
+  display: grid;
+  padding: 0.28rem 0;
+  border-bottom: 1px solid rgba(134, 240, 210, 0.08);
+  color: var(--screen-ink);
+  font:
+    600 0.66rem/1.4 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  grid-template-columns: 5.2rem 3.2rem minmax(0, 1fr);
+  gap: 0.5rem;
+}
+
+.logTime {
+  opacity: 0.55;
+}
+
+.logKind {
+  font-weight: 700;
+}
+
+.log_ok .logKind {
+  color: #86f0d2;
+}
+
+.log_err .logKind,
+.log_err {
+  color: #ff8f7d;
+}
+
+.log_warn .logKind {
+  color: #f0b45a;
+}
+
+.log_info .logKind {
+  color: #9fd8ff;
+}
+
+.log_done .logKind {
+  color: #ffffff;
+}
+
+.logIdle {
+  color: rgba(207, 251, 236, 0.5);
+  grid-template-columns: minmax(0, 1fr) !important;
+}
+
+.faultBlock {
+  margin-top: 1.1rem;
+  padding: 0.8rem 0.9rem;
+  border: 1px solid color-mix(in srgb, var(--fault) 45%, transparent);
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--fault) 8%, transparent);
+}
+
+.faultTitle {
+  margin: 0;
+  color: var(--fault);
+  font:
+    650 0.56rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.faultLine {
+  margin: 0.45rem 0 0;
+  color: var(--text);
+  font:
+    650 0.74rem/1.4 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+}
+
+.bomFault {
+  border-left: 3px solid rgba(180, 60, 40, 0.5);
+  padding-left: 0.9rem !important;
+}
+
+.bomMetrics {
+  display: grid;
+  margin: 1rem 0 0;
+  border-top: 1px solid rgba(20, 32, 30, 0.25);
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+}
+
+.bomMetrics > div {
+  padding: 0.55rem 0.9rem 0.55rem 0;
+  border-bottom: 1px solid rgba(20, 32, 30, 0.16);
+}
+
+.bomMetrics dt {
+  font:
+    650 0.55rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  opacity: 0.55;
+}
+
+.bomMetrics dd {
+  margin: 0.3rem 0 0;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.blockLabel {
+  margin: 1.2rem 0 0;
+  color: var(--signal);
+  font:
+    650 0.56rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+}
+
+.closing {
+  max-width: 52rem;
+  margin: 0;
+  color: var(--muted);
+  font-size: clamp(1rem, 1.4vw, 1.15rem);
+  line-height: 1.7;
+}
+
+/* ------------------------------------------------------------- responsive */
+
+@media (max-width: 1080px) {
+  .instrument {
+    grid-template-areas:
+      'viewport'
+      'channels'
+      'scope';
+    grid-template-columns: minmax(0, 1fr);
   }
 
-  .heroShade {
-    background: linear-gradient(
-      0deg,
-      rgba(3, 7, 10, 0.99) 0%,
-      rgba(3, 7, 10, 0.5) 73%,
-      rgba(3, 7, 10, 0.58) 100%
-    );
+  .benchHead {
+    grid-template-columns: minmax(0, 1fr);
   }
 
-  .pathExplorer {
-    right: 1.25rem;
-    left: 1.25rem;
-  }
-
-  .pathHeader,
-  .activeLayerBody {
-    grid-template-columns: 1fr;
-    gap: 1rem;
-  }
-
-  .signalPath {
-    grid-template-columns: repeat(3, 1fr);
-  }
-
-  .activeLayerBody blockquote {
-    display: none;
-  }
-
-  .indexGrid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  .modelIntro {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .modelIntro .eyebrow {
-    grid-column: 1 / -1;
-  }
-
-  .loop {
-    grid-template-columns: repeat(2, 1fr);
+  .statusStack {
+    grid-auto-flow: column;
+    justify-content: start;
+    gap: 1.25rem;
   }
 }
 
-@media (max-width: 700px) {
-  .hero {
-    min-height: 92rem;
+@media (max-width: 720px) {
+  .viewportInner {
+    aspect-ratio: 4 / 3;
   }
 
-  .heroHeading {
-    top: 2.8rem;
+  .bomRow {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1rem;
   }
 
-  .heroHeading h1 {
-    font-size: clamp(3.25rem, 15.5vw, 5rem);
+  .measured > div {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.15rem;
   }
 
-  .pathExplorer {
-    right: 1rem;
-    bottom: 2rem;
-    left: 1rem;
-    padding: 0.8rem;
-  }
-
-  .pathTabs {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .pathTab,
-  .pathTabActive {
-    width: 100%;
-  }
-
-  .signalPath {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  .layerNode {
-    min-height: 6.6rem;
-  }
-
-  .activeLayerHeading {
-    grid-template-columns: 2rem 1fr;
-  }
-
-  .activeLayerHeading strong {
-    grid-column: 2;
-  }
-
-  .sectionHeading,
-  .next,
-  .modelIntro {
-    grid-template-columns: 1fr;
-    gap: 2rem;
-  }
-
-  .modelIntro .eyebrow {
-    grid-column: auto;
-  }
-
-  .indexGrid,
-  .loop {
-    grid-template-columns: 1fr;
-  }
-
-  .indexCard {
-    min-height: 20rem;
-  }
-
-  .loop li {
-    min-height: 13rem;
+  .coach {
+    right: 0.75rem;
+    bottom: 2.6rem;
+    left: 0.75rem;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .pathTab,
-  .pathTabActive,
-  .layerNode {
-    transition: none;
+  .trace path,
+  .ledSignal,
+  .coach {
+    animation: none;
+  }
+}
+
+/* systems viewport is a wide cross-section, not a square object */
+.viewportInner {
+  aspect-ratio: 21 / 9;
+}
+
+@media (max-width: 720px) {
+  .viewportInner {
+    aspect-ratio: 4 / 3;
   }
 }

--- a/components/machine/cutaway-scene.tsx
+++ b/components/machine/cutaway-scene.tsx
@@ -46,11 +46,13 @@ const moduleX = (index: number) => (index - (stages.length - 1) / 2) * PITCH
 function drawPlate(index: number, theme: MachineTheme) {
   const stage = stages[index]
   const palette = machinePalettes[theme]
-  const ink = theme === 'dark' ? 'rgba(226, 240, 235, 0.95)' : 'rgba(20, 30, 28, 0.95)'
+  const ink =
+    theme === 'dark' ? 'rgba(226, 240, 235, 0.95)' : 'rgba(20, 30, 28, 0.95)'
   return makeCanvasTexture(512, 128, (ctx) => {
     ctx.fillStyle = theme === 'dark' ? '#0d1618' : '#d8d4c9'
     ctx.fillRect(0, 0, 512, 128)
-    ctx.strokeStyle = theme === 'dark' ? 'rgba(226, 240, 235, 0.25)' : 'rgba(20, 30, 28, 0.3)'
+    ctx.strokeStyle =
+      theme === 'dark' ? 'rgba(226, 240, 235, 0.25)' : 'rgba(20, 30, 28, 0.3)'
     ctx.lineWidth = 4
     ctx.strokeRect(6, 6, 500, 116)
     ctx.fillStyle = palette.signalCss
@@ -100,10 +102,18 @@ export function CutawayScene(props: CutawaySceneProps) {
         theme === 'dark' ? 0.8 : 1.4
       )
     )
-    const key = new THREE.DirectionalLight(0xffffff, theme === 'dark' ? 1.8 : 2.4)
+    const key = new THREE.DirectionalLight(
+      0xffffff,
+      theme === 'dark' ? 1.8 : 2.4
+    )
     key.position.set(4, 9, 11)
     scene.add(key)
-    const rim = new THREE.PointLight(palette.signal, theme === 'dark' ? 30 : 12, 34, 2)
+    const rim = new THREE.PointLight(
+      palette.signal,
+      theme === 'dark' ? 30 : 12,
+      34,
+      2
+    )
     rim.position.set(-8, 3, 6)
     scene.add(rim)
 
@@ -115,7 +125,7 @@ export function CutawayScene(props: CutawaySceneProps) {
     // ---- cutaway shells (instanced slabs) ---------------------------------
     const SLABS = 5
     const shellMaterial = new THREE.MeshStandardMaterial({
-      color: theme === 'dark' ? 0x131c1e : 0x9c9890,
+      color: 0xffffff,
       roughness: 0.6,
       metalness: 0.5
     })
@@ -124,7 +134,13 @@ export function CutawayScene(props: CutawaySceneProps) {
       shellMaterial,
       stages.length * SLABS
     )
+    shells.instanceColor = new THREE.InstancedBufferAttribute(
+      new Float32Array(stages.length * SLABS * 3),
+      3
+    )
     root.add(shells)
+    const shellBase = new THREE.Color(theme === 'dark' ? 0x1b2628 : 0x8c8880)
+    const shellBack = new THREE.Color(theme === 'dark' ? 0x080e10 : 0x4a4f4c)
 
     // ---- internals (instanced) -------------------------------------------
     const INNER = 7
@@ -147,7 +163,10 @@ export function CutawayScene(props: CutawaySceneProps) {
     const plates = stages.map((_, index) => {
       const plate = new THREE.Mesh(
         new THREE.PlaneGeometry(MODULE_W * 0.92, MODULE_W * 0.92 * 0.25),
-        new THREE.MeshBasicMaterial({ map: drawPlate(index, theme), transparent: true })
+        new THREE.MeshBasicMaterial({
+          map: drawPlate(index, theme),
+          transparent: true
+        })
       )
       plate.position.set(moduleX(index), -MODULE_H / 2 - 0.55, MODULE_D / 2)
       plate.userData.stageId = stages[index].id
@@ -210,13 +229,22 @@ export function CutawayScene(props: CutawaySceneProps) {
     root.add(bypass)
 
     // ---- packet + trail ---------------------------------------------------
-    const packetMaterial = new THREE.MeshBasicMaterial({ color: palette.signal })
-    const packet = new THREE.Mesh(new THREE.BoxGeometry(0.4, 0.4, 0.4), packetMaterial)
+    const packetMaterial = new THREE.MeshBasicMaterial({
+      color: palette.signal
+    })
+    const packet = new THREE.Mesh(
+      new THREE.BoxGeometry(0.4, 0.4, 0.4),
+      packetMaterial
+    )
     root.add(packet)
     const TRAIL = 26
     const trail = new THREE.InstancedMesh(
       new THREE.BoxGeometry(0.16, 0.16, 0.16),
-      new THREE.MeshBasicMaterial({ color: palette.signal, transparent: true, opacity: 0.55 }),
+      new THREE.MeshBasicMaterial({
+        color: palette.signal,
+        transparent: true,
+        opacity: 0.55
+      }),
       TRAIL
     )
     trail.frustumCulled = false
@@ -240,15 +268,22 @@ export function CutawayScene(props: CutawaySceneProps) {
     const target = new THREE.Vector3(0, -0.2, 0)
     let hovered: string | null = null
 
+    let focusMode = false
     const resize = () => {
       const width = host.clientWidth
       const height = host.clientHeight
       if (!width || !height) return
       renderer.setSize(width, height, false)
       camera.aspect = width / height
-      const halfSpan = (EXIT_X - ENTRY_X) / 2 + 0.6
+      // Narrow viewports track the packet through two modules instead of
+      // shrinking the whole machine into an unreadable strip.
+      focusMode = camera.aspect < 1.3
+      const halfSpan = focusMode ? PITCH * 1.05 : (EXIT_X - ENTRY_X) / 2 + 0.6
       const fitHeight = Math.max(3.6, halfSpan / camera.aspect)
-      state.radius = Math.min(70, fitHeight / Math.tan((camera.fov * Math.PI) / 360) + 2)
+      state.radius = Math.min(
+        70,
+        fitHeight / Math.tan((camera.fov * Math.PI) / 360) + 2
+      )
       camera.updateProjectionMatrix()
     }
 
@@ -277,9 +312,20 @@ export function CutawayScene(props: CutawaySceneProps) {
     }
     const handleMove = (event: PointerEvent) => {
       if (state.dragging && pointerId === event.pointerId) {
-        moved = Math.max(moved, Math.hypot(event.clientX - downX, event.clientY - downY))
-        state.targetAzimuth = clamp(state.targetAzimuth + event.movementX * 0.004, -0.55, 0.55)
-        state.targetPolar = clamp(state.targetPolar - event.movementY * 0.003, -0.15, 0.55)
+        moved = Math.max(
+          moved,
+          Math.hypot(event.clientX - downX, event.clientY - downY)
+        )
+        state.targetAzimuth = clamp(
+          state.targetAzimuth + event.movementX * 0.004,
+          -0.55,
+          0.55
+        )
+        state.targetPolar = clamp(
+          state.targetPolar - event.movementY * 0.003,
+          -0.15,
+          0.55
+        )
         return
       }
       const id = pick(event)
@@ -301,10 +347,14 @@ export function CutawayScene(props: CutawaySceneProps) {
     }
     const handleKey = (event: KeyboardEvent) => {
       const step = 0.1
-      if (event.key === 'ArrowLeft') state.targetAzimuth = clamp(state.targetAzimuth - step, -0.55, 0.55)
-      else if (event.key === 'ArrowRight') state.targetAzimuth = clamp(state.targetAzimuth + step, -0.55, 0.55)
-      else if (event.key === 'ArrowUp') state.targetPolar = clamp(state.targetPolar + step, -0.15, 0.55)
-      else if (event.key === 'ArrowDown') state.targetPolar = clamp(state.targetPolar - step, -0.15, 0.55)
+      if (event.key === 'ArrowLeft')
+        state.targetAzimuth = clamp(state.targetAzimuth - step, -0.55, 0.55)
+      else if (event.key === 'ArrowRight')
+        state.targetAzimuth = clamp(state.targetAzimuth + step, -0.55, 0.55)
+      else if (event.key === 'ArrowUp')
+        state.targetPolar = clamp(state.targetPolar + step, -0.15, 0.55)
+      else if (event.key === 'ArrowDown')
+        state.targetPolar = clamp(state.targetPolar - step, -0.15, 0.55)
       else return
       event.preventDefault()
     }
@@ -403,7 +453,9 @@ export function CutawayScene(props: CutawaySceneProps) {
         packetY = damp(packetY, -1.75, 7, delta)
         const index = stageAt(packetX)
         if (index === -1 && packetX > 0) {
-          const passed = stages.findIndex((_, i) => packetX > moduleX(i) + MODULE_W / 2)
+          const passed = stages.findIndex(
+            (_, i) => packetX > moduleX(i) + MODULE_W / 2
+          )
           if (passed >= 0) {
             phase = 'flow'
             onEvent('rejoin', stages[Math.max(0, passed)].id, elapsed)
@@ -419,6 +471,10 @@ export function CutawayScene(props: CutawaySceneProps) {
       }
 
       // camera
+      const focusX = focusMode
+        ? clamp(packetX, moduleX(0), moduleX(stages.length - 1))
+        : 0
+      target.x = damp(target.x, focusX, 3.2, delta)
       state.azimuth = damp(state.azimuth, state.targetAzimuth, 6, delta)
       state.polar = damp(state.polar, state.targetPolar, 6, delta)
       camera.position.set(
@@ -429,7 +485,6 @@ export function CutawayScene(props: CutawaySceneProps) {
       camera.lookAt(target)
 
       // modules
-      const shellColor = new THREE.Color(theme === 'dark' ? 0x131c1e : 0x9c9890)
       const faultColor = new THREE.Color(palette.fault)
       const okColor = new THREE.Color(palette.signal)
       const idleColor = new THREE.Color(theme === 'dark' ? 0x1d2b2b : 0x5c6663)
@@ -462,6 +517,10 @@ export function CutawayScene(props: CutawaySceneProps) {
           dummy.rotation.set(0, 0, 0)
           dummy.updateMatrix()
           shells.setMatrixAt(index * SLABS + slabIndex, dummy.matrix)
+          color.copy(slabIndex === 2 ? shellBack : shellBase)
+          if (faultLevel[index] > 0.01)
+            color.lerp(faultColor, faultLevel[index] * 0.35)
+          shells.setColorAt(index * SLABS + slabIndex, color)
         })
 
         for (let inner = 0; inner < INNER; inner += 1) {
@@ -485,13 +544,21 @@ export function CutawayScene(props: CutawaySceneProps) {
         }
 
         const plate = plates[index]
-        plate.position.set(cx, cy - MODULE_H / 2 - 0.55, cz + MODULE_D / 2 + 0.02)
+        plate.position.set(
+          cx,
+          cy - MODULE_H / 2 - 0.55,
+          cz + MODULE_D / 2 + 0.02
+        )
         ;(plate.material as THREE.MeshBasicMaterial).color
           .copy(new THREE.Color(0xffffff))
           .lerp(faultColor, faultLevel[index] * 0.75)
 
         const openBreaker =
-          faulted && (phase === 'bypass' || packetX > moduleX(index)) ? 1 : faulted ? 0.15 : 0
+          faulted && (phase === 'bypass' || packetX > moduleX(index))
+            ? 1
+            : faulted
+              ? 0.15
+              : 0
         shutterLevel[index] = damp(shutterLevel[index], openBreaker, 8, delta)
         const shutter = shutters[index]
         shutter.scale.y = Math.max(0.001, shutterLevel[index])
@@ -500,12 +567,14 @@ export function CutawayScene(props: CutawaySceneProps) {
           cy + (MODULE_H / 2) * (1 - shutterLevel[index]),
           cz + MODULE_D / 2 - 0.2
         )
-        ;(shutter.material as THREE.MeshStandardMaterial).opacity = 0.85 * shutterLevel[index]
+        ;(shutter.material as THREE.MeshStandardMaterial).opacity =
+          0.85 * shutterLevel[index]
 
         const hit = clickable[index]
         hit.position.set(cx, cy - 0.2, cz)
       })
       shells.instanceMatrix.needsUpdate = true
+      if (shells.instanceColor) shells.instanceColor.needsUpdate = true
       internals.instanceMatrix.needsUpdate = true
       if (internals.instanceColor) internals.instanceColor.needsUpdate = true
 
@@ -525,7 +594,6 @@ export function CutawayScene(props: CutawaySceneProps) {
       trail.instanceMatrix.needsUpdate = true
 
       rim.position.set(packetX, 1.5, 4)
-      shellMaterial.color.copy(shellColor)
 
       renderer.render(scene, camera)
     }

--- a/components/machine/cutaway-scene.tsx
+++ b/components/machine/cutaway-scene.tsx
@@ -1,0 +1,594 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import * as THREE from 'three'
+import { stages } from '@/app/systems/systems-data'
+import {
+  damp,
+  disposeObject,
+  machinePalettes,
+  makeCanvasTexture,
+  monoFont,
+  type MachineTheme
+} from './machine-core'
+import styles from './rack-scene.module.css'
+
+export type MachineEvent =
+  | 'enter'
+  | 'fault'
+  | 'breaker'
+  | 'bypass'
+  | 'rejoin'
+  | 'complete'
+
+type CutawaySceneProps = {
+  theme: MachineTheme
+  running: boolean
+  speed: number
+  explode: number
+  faults: Record<string, boolean>
+  activeId: string
+  stepToken: number
+  onSelect: (id: string) => void
+  onHover: (id: string | null) => void
+  onEvent: (event: MachineEvent, stageId: string, at: number) => void
+}
+
+const MODULE_W = 3.1
+const PITCH = 3.9
+const MODULE_H = 3.2
+const MODULE_D = 2.6
+const ENTRY_X = -((stages.length - 1) * PITCH) / 2 - 2.2
+const EXIT_X = ((stages.length - 1) * PITCH) / 2 + 2.2
+
+const moduleX = (index: number) => (index - (stages.length - 1) / 2) * PITCH
+
+function drawPlate(index: number, theme: MachineTheme) {
+  const stage = stages[index]
+  const palette = machinePalettes[theme]
+  const ink = theme === 'dark' ? 'rgba(226, 240, 235, 0.95)' : 'rgba(20, 30, 28, 0.95)'
+  return makeCanvasTexture(512, 128, (ctx) => {
+    ctx.fillStyle = theme === 'dark' ? '#0d1618' : '#d8d4c9'
+    ctx.fillRect(0, 0, 512, 128)
+    ctx.strokeStyle = theme === 'dark' ? 'rgba(226, 240, 235, 0.25)' : 'rgba(20, 30, 28, 0.3)'
+    ctx.lineWidth = 4
+    ctx.strokeRect(6, 6, 500, 116)
+    ctx.fillStyle = palette.signalCss
+    ctx.font = monoFont(40, 700)
+    ctx.textBaseline = 'middle'
+    ctx.fillText(stage.code, 26, 64)
+    ctx.fillStyle = ink
+    ctx.font = monoFont(38, 700)
+    ctx.fillText(stage.name.toUpperCase(), 108, 56)
+    ctx.font = monoFont(18, 500)
+    ctx.globalAlpha = 0.65
+    ctx.fillText(stage.tools.slice(0, 3).join(' · ').toUpperCase(), 108, 96)
+  })
+}
+
+export function CutawayScene(props: CutawaySceneProps) {
+  const { theme } = props
+  const hostRef = useRef<HTMLDivElement>(null)
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const controls = useRef(props)
+  controls.current = props
+
+  useEffect(() => {
+    const host = hostRef.current
+    const canvas = canvasRef.current
+    if (!host || !canvas) return
+
+    const palette = machinePalettes[theme]
+    let renderer: THREE.WebGLRenderer
+    try {
+      renderer = new THREE.WebGLRenderer({ canvas, antialias: true })
+    } catch {
+      return
+    }
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 1.75))
+    renderer.setClearColor(palette.clear, 1)
+    renderer.outputColorSpace = THREE.SRGBColorSpace
+
+    const scene = new THREE.Scene()
+    scene.background = new THREE.Color(palette.clear)
+    const camera = new THREE.PerspectiveCamera(34, 1, 0.5, 140)
+
+    scene.add(
+      new THREE.HemisphereLight(
+        theme === 'dark' ? 0x8fd8cc : 0xffffff,
+        theme === 'dark' ? 0x0a1416 : 0xa9a196,
+        theme === 'dark' ? 0.8 : 1.4
+      )
+    )
+    const key = new THREE.DirectionalLight(0xffffff, theme === 'dark' ? 1.8 : 2.4)
+    key.position.set(4, 9, 11)
+    scene.add(key)
+    const rim = new THREE.PointLight(palette.signal, theme === 'dark' ? 30 : 12, 34, 2)
+    rim.position.set(-8, 3, 6)
+    scene.add(rim)
+
+    const root = new THREE.Group()
+    scene.add(root)
+    const dummy = new THREE.Object3D()
+    const color = new THREE.Color()
+
+    // ---- cutaway shells (instanced slabs) ---------------------------------
+    const SLABS = 5
+    const shellMaterial = new THREE.MeshStandardMaterial({
+      color: theme === 'dark' ? 0x131c1e : 0x9c9890,
+      roughness: 0.6,
+      metalness: 0.5
+    })
+    const shells = new THREE.InstancedMesh(
+      new THREE.BoxGeometry(1, 1, 1),
+      shellMaterial,
+      stages.length * SLABS
+    )
+    root.add(shells)
+
+    // ---- internals (instanced) -------------------------------------------
+    const INNER = 7
+    const innerMaterial = new THREE.MeshStandardMaterial({
+      roughness: 0.45,
+      metalness: 0.2
+    })
+    const internals = new THREE.InstancedMesh(
+      new THREE.BoxGeometry(0.42, 0.42, 0.42),
+      innerMaterial,
+      stages.length * INNER
+    )
+    internals.instanceColor = new THREE.InstancedBufferAttribute(
+      new Float32Array(stages.length * INNER * 3),
+      3
+    )
+    root.add(internals)
+
+    // ---- nameplates -------------------------------------------------------
+    const plates = stages.map((_, index) => {
+      const plate = new THREE.Mesh(
+        new THREE.PlaneGeometry(MODULE_W * 0.92, MODULE_W * 0.92 * 0.25),
+        new THREE.MeshBasicMaterial({ map: drawPlate(index, theme), transparent: true })
+      )
+      plate.position.set(moduleX(index), -MODULE_H / 2 - 0.55, MODULE_D / 2)
+      plate.userData.stageId = stages[index].id
+      root.add(plate)
+      return plate
+    })
+
+    // hit targets
+    const clickable = stages.map((stage, index) => {
+      const hit = new THREE.Mesh(
+        new THREE.BoxGeometry(MODULE_W + 0.6, MODULE_H + 1.6, MODULE_D + 0.6),
+        new THREE.MeshBasicMaterial({ visible: false })
+      )
+      hit.position.set(moduleX(index), -0.2, 0)
+      hit.userData.stageId = stage.id
+      root.add(hit)
+      return hit
+    })
+
+    // ---- shutters (breaker) ----------------------------------------------
+    const shutters = stages.map((_, index) => {
+      const shutter = new THREE.Mesh(
+        new THREE.BoxGeometry(MODULE_W * 0.96, MODULE_H * 0.9, 0.12),
+        new THREE.MeshStandardMaterial({
+          color: palette.fault,
+          roughness: 0.5,
+          transparent: true,
+          opacity: 0.9
+        })
+      )
+      shutter.position.set(moduleX(index), MODULE_H, MODULE_D / 2 - 0.2)
+      shutter.scale.y = 0.001
+      root.add(shutter)
+      return shutter
+    })
+
+    // ---- rails ------------------------------------------------------------
+    const railMaterial = new THREE.MeshStandardMaterial({
+      color: theme === 'dark' ? 0x27332f : 0x6f7a74,
+      roughness: 0.6,
+      metalness: 0.6
+    })
+    const rail = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.09, 0.09, EXIT_X - ENTRY_X, 10),
+      railMaterial
+    )
+    rail.rotation.z = Math.PI / 2
+    rail.position.set((ENTRY_X + EXIT_X) / 2, 0, 0)
+    root.add(rail)
+
+    const bypass = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.06, 0.06, EXIT_X - ENTRY_X, 8),
+      new THREE.MeshStandardMaterial({
+        color: theme === 'dark' ? 0x1d2a28 : 0x7d867f,
+        roughness: 0.7
+      })
+    )
+    bypass.rotation.z = Math.PI / 2
+    bypass.position.set((ENTRY_X + EXIT_X) / 2, -1.75, 0)
+    root.add(bypass)
+
+    // ---- packet + trail ---------------------------------------------------
+    const packetMaterial = new THREE.MeshBasicMaterial({ color: palette.signal })
+    const packet = new THREE.Mesh(new THREE.BoxGeometry(0.4, 0.4, 0.4), packetMaterial)
+    root.add(packet)
+    const TRAIL = 26
+    const trail = new THREE.InstancedMesh(
+      new THREE.BoxGeometry(0.16, 0.16, 0.16),
+      new THREE.MeshBasicMaterial({ color: palette.signal, transparent: true, opacity: 0.55 }),
+      TRAIL
+    )
+    trail.frustumCulled = false
+    root.add(trail)
+    const history: THREE.Vector3[] = Array.from(
+      { length: TRAIL },
+      () => new THREE.Vector3(ENTRY_X, 0, 0)
+    )
+
+    // ---- interaction ------------------------------------------------------
+    const state = {
+      azimuth: -0.1,
+      polar: 0.16,
+      targetAzimuth: -0.1,
+      targetPolar: 0.16,
+      radius: 30,
+      dragging: false
+    }
+    const raycaster = new THREE.Raycaster()
+    const pointer = new THREE.Vector2()
+    const target = new THREE.Vector3(0, -0.2, 0)
+    let hovered: string | null = null
+
+    const resize = () => {
+      const width = host.clientWidth
+      const height = host.clientHeight
+      if (!width || !height) return
+      renderer.setSize(width, height, false)
+      camera.aspect = width / height
+      const halfSpan = (EXIT_X - ENTRY_X) / 2 + 0.6
+      const fitHeight = Math.max(3.6, halfSpan / camera.aspect)
+      state.radius = Math.min(70, fitHeight / Math.tan((camera.fov * Math.PI) / 360) + 2)
+      camera.updateProjectionMatrix()
+    }
+
+    const pick = (event: PointerEvent) => {
+      const bounds = canvas.getBoundingClientRect()
+      pointer.x = ((event.clientX - bounds.left) / bounds.width) * 2 - 1
+      pointer.y = -((event.clientY - bounds.top) / bounds.height) * 2 + 1
+      raycaster.setFromCamera(pointer, camera)
+      const hit = raycaster.intersectObjects(clickable, false)[0]
+      return (hit?.object.userData.stageId as string | undefined) ?? null
+    }
+
+    let pointerId: number | null = null
+    let downX = 0
+    let downY = 0
+    let moved = 0
+
+    const handleDown = (event: PointerEvent) => {
+      pointerId = event.pointerId
+      downX = event.clientX
+      downY = event.clientY
+      moved = 0
+      state.dragging = true
+      canvas.setPointerCapture(event.pointerId)
+      canvas.style.cursor = 'grabbing'
+    }
+    const handleMove = (event: PointerEvent) => {
+      if (state.dragging && pointerId === event.pointerId) {
+        moved = Math.max(moved, Math.hypot(event.clientX - downX, event.clientY - downY))
+        state.targetAzimuth = clamp(state.targetAzimuth + event.movementX * 0.004, -0.55, 0.55)
+        state.targetPolar = clamp(state.targetPolar - event.movementY * 0.003, -0.15, 0.55)
+        return
+      }
+      const id = pick(event)
+      if (id !== hovered) {
+        hovered = id
+        canvas.style.cursor = id ? 'pointer' : 'grab'
+        controls.current.onHover(id)
+      }
+    }
+    const handleUp = (event: PointerEvent) => {
+      if (pointerId !== event.pointerId) return
+      state.dragging = false
+      pointerId = null
+      canvas.releasePointerCapture?.(event.pointerId)
+      if (moved < 6) {
+        const id = pick(event)
+        if (id) controls.current.onSelect(id)
+      }
+    }
+    const handleKey = (event: KeyboardEvent) => {
+      const step = 0.1
+      if (event.key === 'ArrowLeft') state.targetAzimuth = clamp(state.targetAzimuth - step, -0.55, 0.55)
+      else if (event.key === 'ArrowRight') state.targetAzimuth = clamp(state.targetAzimuth + step, -0.55, 0.55)
+      else if (event.key === 'ArrowUp') state.targetPolar = clamp(state.targetPolar + step, -0.15, 0.55)
+      else if (event.key === 'ArrowDown') state.targetPolar = clamp(state.targetPolar - step, -0.15, 0.55)
+      else return
+      event.preventDefault()
+    }
+
+    canvas.addEventListener('pointerdown', handleDown)
+    canvas.addEventListener('pointermove', handleMove)
+    canvas.addEventListener('pointerup', handleUp)
+    canvas.addEventListener('pointercancel', handleUp)
+    canvas.addEventListener('keydown', handleKey)
+    canvas.style.cursor = 'grab'
+
+    // ---- transport state --------------------------------------------------
+    let packetX = ENTRY_X
+    let packetY = 0
+    let phase: 'flow' | 'stalled' | 'bypass' = 'flow'
+    let stallTimer = 0
+    let lastStage = -1
+    let elapsed = 0
+    let lastToken = controls.current.stepToken
+    let stepping = false
+    let stepTarget = 0
+    const shutterLevel = stages.map(() => 0)
+    const faultLevel = stages.map(() => 0)
+
+    const stageAt = (x: number) => {
+      for (let index = 0; index < stages.length; index += 1) {
+        if (Math.abs(x - moduleX(index)) <= MODULE_W / 2) return index
+      }
+      return -1
+    }
+
+    const reset = () => {
+      packetX = ENTRY_X
+      packetY = 0
+      phase = 'flow'
+      lastStage = -1
+      elapsed = 0
+      history.forEach((point) => point.set(ENTRY_X, 0, 0))
+    }
+
+    const clock = new THREE.Clock()
+    let frame = 0
+    let inView = true
+    let visible = !document.hidden
+
+    const renderFrame = () => {
+      const delta = Math.min(clock.getDelta(), 0.05)
+      const { running, speed, explode, faults, activeId, stepToken, onEvent } =
+        controls.current
+
+      if (stepToken !== lastToken) {
+        lastToken = stepToken
+        const current = stageAt(packetX)
+        const next = current + 1
+        stepTarget =
+          next >= stages.length ? EXIT_X : moduleX(next) - MODULE_W / 2 + 0.35
+        stepping = true
+      }
+
+      const moving = running || stepping
+      if (moving && phase !== 'stalled') {
+        packetX += delta * speed * 3.4
+        elapsed += delta * speed * 3.4 * 14
+        if (stepping && packetX >= stepTarget) {
+          packetX = stepTarget
+          stepping = false
+        }
+      }
+
+      const current = stageAt(packetX)
+      if (current !== lastStage && current >= 0) {
+        lastStage = current
+        onEvent('enter', stages[current].id, elapsed)
+        if (faults[stages[current].id]) {
+          phase = 'stalled'
+          stallTimer = 0
+          onEvent('fault', stages[current].id, elapsed)
+        }
+      }
+      if (current < 0 && packetX > moduleX(stages.length - 1)) lastStage = -1
+
+      if (phase === 'stalled') {
+        stallTimer += delta * (running ? speed : 1)
+        elapsed += delta * speed * 210
+        if (stallTimer > 1.1) {
+          const index = Math.max(0, stageAt(packetX))
+          onEvent('breaker', stages[index].id, elapsed)
+          onEvent('bypass', stages[index].id, elapsed + 40)
+          phase = 'bypass'
+        }
+      }
+
+      if (phase === 'bypass') {
+        packetX += delta * speed * 3.4
+        elapsed += delta * speed * 3.4 * 14
+        packetY = damp(packetY, -1.75, 7, delta)
+        const index = stageAt(packetX)
+        if (index === -1 && packetX > 0) {
+          const passed = stages.findIndex((_, i) => packetX > moduleX(i) + MODULE_W / 2)
+          if (passed >= 0) {
+            phase = 'flow'
+            onEvent('rejoin', stages[Math.max(0, passed)].id, elapsed)
+          }
+        }
+      } else {
+        packetY = damp(packetY, 0, 7, delta)
+      }
+
+      if (packetX > EXIT_X) {
+        onEvent('complete', 'feedback', elapsed)
+        reset()
+      }
+
+      // camera
+      state.azimuth = damp(state.azimuth, state.targetAzimuth, 6, delta)
+      state.polar = damp(state.polar, state.targetPolar, 6, delta)
+      camera.position.set(
+        target.x + state.radius * Math.sin(state.azimuth),
+        target.y + state.radius * Math.sin(state.polar),
+        state.radius * Math.cos(state.azimuth) * Math.cos(state.polar)
+      )
+      camera.lookAt(target)
+
+      // modules
+      const shellColor = new THREE.Color(theme === 'dark' ? 0x131c1e : 0x9c9890)
+      const faultColor = new THREE.Color(palette.fault)
+      const okColor = new THREE.Color(palette.signal)
+      const idleColor = new THREE.Color(theme === 'dark' ? 0x1d2b2b : 0x5c6663)
+
+      stages.forEach((stage, index) => {
+        const faulted = Boolean(faults[stage.id])
+        faultLevel[index] = damp(faultLevel[index], faulted ? 1 : 0, 6, delta)
+        const isActive = stage.id === activeId
+        const isHover = stage.id === hovered
+        const lift = explode * (index - (stages.length - 1) / 2) * 0.55
+        const rise = explode * 1.5 + (isActive ? 0.24 : isHover ? 0.1 : 0)
+        const shake =
+          phase === 'stalled' && stageAt(packetX) === index
+            ? Math.sin(clock.elapsedTime * 40) * 0.04
+            : 0
+        const cx = moduleX(index) + lift + shake
+        const cy = rise
+        const cz = explode * 0.9
+
+        const slabs: [number, number, number, number, number, number][] = [
+          [cx, cy + MODULE_H / 2, cz, MODULE_W, 0.24, MODULE_D],
+          [cx, cy - MODULE_H / 2, cz, MODULE_W, 0.24, MODULE_D],
+          [cx, cy, cz - MODULE_D / 2, MODULE_W, MODULE_H, 0.2],
+          [cx - MODULE_W / 2, cy, cz, 0.2, MODULE_H, MODULE_D],
+          [cx + MODULE_W / 2, cy, cz, 0.2, MODULE_H, MODULE_D]
+        ]
+        slabs.forEach((slab, slabIndex) => {
+          dummy.position.set(slab[0], slab[1], slab[2])
+          dummy.scale.set(slab[3], slab[4], slab[5])
+          dummy.rotation.set(0, 0, 0)
+          dummy.updateMatrix()
+          shells.setMatrixAt(index * SLABS + slabIndex, dummy.matrix)
+        })
+
+        for (let inner = 0; inner < INNER; inner += 1) {
+          const gx = (inner % 4) / 3 - 0.5
+          const gy = inner < 4 ? 0.45 : -0.45
+          dummy.position.set(
+            cx + gx * (MODULE_W - 1.1),
+            cy + gy - 0.1,
+            cz + (inner % 2 === 0 ? 0.2 : -0.5)
+          )
+          dummy.scale.setScalar(isActive ? 1.12 : 1)
+          dummy.rotation.set(0, 0, 0)
+          dummy.updateMatrix()
+          internals.setMatrixAt(index * INNER + inner, dummy.matrix)
+          const busy = stageAt(packetX) === index && phase !== 'stalled'
+          color
+            .copy(idleColor)
+            .lerp(okColor, busy || isActive ? 0.85 : 0.15)
+            .lerp(faultColor, faultLevel[index])
+          internals.setColorAt(index * INNER + inner, color)
+        }
+
+        const plate = plates[index]
+        plate.position.set(cx, cy - MODULE_H / 2 - 0.55, cz + MODULE_D / 2 + 0.02)
+        ;(plate.material as THREE.MeshBasicMaterial).color
+          .copy(new THREE.Color(0xffffff))
+          .lerp(faultColor, faultLevel[index] * 0.75)
+
+        const openBreaker =
+          faulted && (phase === 'bypass' || packetX > moduleX(index)) ? 1 : faulted ? 0.15 : 0
+        shutterLevel[index] = damp(shutterLevel[index], openBreaker, 8, delta)
+        const shutter = shutters[index]
+        shutter.scale.y = Math.max(0.001, shutterLevel[index])
+        shutter.position.set(
+          cx,
+          cy + (MODULE_H / 2) * (1 - shutterLevel[index]),
+          cz + MODULE_D / 2 - 0.2
+        )
+        ;(shutter.material as THREE.MeshStandardMaterial).opacity = 0.85 * shutterLevel[index]
+
+        const hit = clickable[index]
+        hit.position.set(cx, cy - 0.2, cz)
+      })
+      shells.instanceMatrix.needsUpdate = true
+      internals.instanceMatrix.needsUpdate = true
+      if (internals.instanceColor) internals.instanceColor.needsUpdate = true
+
+      // packet + trail
+      packet.position.set(packetX, packetY, 0)
+      packet.rotation.y += delta * 2.4
+      packetMaterial.color.copy(phase === 'flow' ? okColor : faultColor)
+      history.pop()
+      history.unshift(new THREE.Vector3(packetX, packetY, 0))
+      history.forEach((point, index) => {
+        dummy.position.copy(point)
+        dummy.scale.setScalar(1 - index / TRAIL)
+        dummy.rotation.set(0, 0, 0)
+        dummy.updateMatrix()
+        trail.setMatrixAt(index, dummy.matrix)
+      })
+      trail.instanceMatrix.needsUpdate = true
+
+      rim.position.set(packetX, 1.5, 4)
+      shellMaterial.color.copy(shellColor)
+
+      renderer.render(scene, camera)
+    }
+
+    const animate = () => {
+      renderFrame()
+      frame = window.requestAnimationFrame(animate)
+    }
+    const sync = () => {
+      window.cancelAnimationFrame(frame)
+      if (inView && visible) {
+        clock.getDelta()
+        frame = window.requestAnimationFrame(animate)
+      }
+    }
+
+    const resizeObserver = new ResizeObserver(resize)
+    resizeObserver.observe(host)
+    const intersection = new IntersectionObserver(
+      ([entry]) => {
+        inView = entry.isIntersecting
+        sync()
+      },
+      { threshold: 0.02 }
+    )
+    intersection.observe(host)
+    const handleVisibility = () => {
+      visible = !document.hidden
+      sync()
+    }
+    document.addEventListener('visibilitychange', handleVisibility)
+
+    resize()
+    sync()
+
+    return () => {
+      window.cancelAnimationFrame(frame)
+      resizeObserver.disconnect()
+      intersection.disconnect()
+      document.removeEventListener('visibilitychange', handleVisibility)
+      canvas.removeEventListener('pointerdown', handleDown)
+      canvas.removeEventListener('pointermove', handleMove)
+      canvas.removeEventListener('pointerup', handleUp)
+      canvas.removeEventListener('pointercancel', handleUp)
+      canvas.removeEventListener('keydown', handleKey)
+      disposeObject(scene)
+      renderer.dispose()
+    }
+  }, [theme])
+
+  return (
+    <div ref={hostRef} className={styles.host}>
+      <canvas
+        ref={canvasRef}
+        className={styles.canvas}
+        tabIndex={0}
+        role="application"
+        aria-label="Cutaway of a request path through five stages. Drag to tilt, arrow keys to rotate, click a module to read it. Transport and fault controls are available as buttons, and the same information is written out below."
+      />
+    </div>
+  )
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max)
+}

--- a/components/machine/machine-core.ts
+++ b/components/machine/machine-core.ts
@@ -1,0 +1,192 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import * as THREE from 'three'
+
+export type MachineTheme = 'dark' | 'light'
+
+export type MachinePalette = {
+  clear: number
+  board: number
+  boardEdge: number
+  silk: string
+  silkFaint: string
+  soldermask: string
+  copper: string
+  copperLit: string
+  pour: string
+  chip: number
+  chipMark: string
+  chipBody: string
+  metal: number
+  gold: number
+  signal: number
+  signalCss: string
+  warn: number
+  fault: number
+  ok: number
+  labelBg: string
+  labelInk: string
+}
+
+export const machinePalettes: Record<MachineTheme, MachinePalette> = {
+  dark: {
+    clear: 0x080d0f,
+    board: 0x0e2a27,
+    boardEdge: 0x1d2b26,
+    silk: 'rgba(226, 240, 235, 0.92)',
+    silkFaint: 'rgba(226, 240, 235, 0.34)',
+    soldermask: '#0d2b28',
+    copper: 'rgba(190, 146, 74, 0.55)',
+    copperLit: 'rgba(134, 240, 210, 0.9)',
+    pour: 'rgba(120, 200, 180, 0.07)',
+    chip: 0x14191b,
+    chipMark: 'rgba(214, 232, 226, 0.86)',
+    chipBody: '#14191b',
+    metal: 0x8d9a9c,
+    gold: 0xd6ac5e,
+    signal: 0x86f0d2,
+    signalCss: '#86f0d2',
+    warn: 0xf0b45a,
+    fault: 0xff6b57,
+    ok: 0x6fe0a8,
+    labelBg: 'rgba(8, 13, 15, 0.82)',
+    labelInk: '#dcebe6'
+  },
+  light: {
+    clear: 0xf1ebe0,
+    board: 0x123c37,
+    boardEdge: 0x2b3a33,
+    silk: 'rgba(240, 246, 242, 0.95)',
+    silkFaint: 'rgba(240, 246, 242, 0.4)',
+    soldermask: '#123c37',
+    copper: 'rgba(219, 176, 100, 0.62)',
+    copperLit: 'rgba(150, 255, 222, 0.95)',
+    pour: 'rgba(150, 220, 200, 0.09)',
+    chip: 0x1b2224,
+    chipMark: 'rgba(226, 238, 233, 0.9)',
+    chipBody: '#1b2224',
+    metal: 0x9aa6a6,
+    gold: 0xc99a45,
+    signal: 0x0e7f68,
+    signalCss: '#0e7f68',
+    warn: 0xb5691a,
+    fault: 0xb8402c,
+    ok: 0x1c7a52,
+    labelBg: 'rgba(246, 241, 232, 0.9)',
+    labelInk: '#16211f'
+  }
+}
+
+/**
+ * Tracks the document theme class written by next-themes (`.dark` / `.light`),
+ * falling back to the OS preference when no class is present.
+ */
+export function useMachineTheme(): MachineTheme {
+  const [theme, setTheme] = useState<MachineTheme>('dark')
+
+  useEffect(() => {
+    const root = document.documentElement
+    const read = (): MachineTheme => {
+      if (root.classList.contains('dark')) return 'dark'
+      if (root.classList.contains('light')) return 'light'
+      return window.matchMedia('(prefers-color-scheme: light)').matches
+        ? 'light'
+        : 'dark'
+    }
+    setTheme(read())
+    const observer = new MutationObserver(() => setTheme(read()))
+    observer.observe(root, { attributes: true, attributeFilter: ['class'] })
+    return () => observer.disconnect()
+  }, [])
+
+  return theme
+}
+
+/** True when the visitor asked for reduced motion. */
+export function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false)
+
+  useEffect(() => {
+    const query = window.matchMedia('(prefers-reduced-motion: reduce)')
+    setReduced(query.matches)
+    const handle = (event: MediaQueryListEvent) => setReduced(event.matches)
+    query.addEventListener('change', handle)
+    return () => query.removeEventListener('change', handle)
+  }, [])
+
+  return reduced
+}
+
+/** Cheap WebGL capability probe, evaluated once after mount. */
+export function useWebglSupported(): boolean | null {
+  const [supported, setSupported] = useState<boolean | null>(null)
+
+  useEffect(() => {
+    try {
+      const canvas = document.createElement('canvas')
+      setSupported(
+        Boolean(
+          canvas.getContext('webgl2') ||
+            canvas.getContext('webgl') ||
+            canvas.getContext('experimental-webgl')
+        )
+      )
+    } catch {
+      setSupported(false)
+    }
+  }, [])
+
+  return supported
+}
+
+export function makeCanvasTexture(
+  width: number,
+  height: number,
+  draw: (context: CanvasRenderingContext2D) => void
+) {
+  const canvas = document.createElement('canvas')
+  canvas.width = width
+  canvas.height = height
+  const context = canvas.getContext('2d')
+  if (context) draw(context)
+  const texture = new THREE.CanvasTexture(canvas)
+  texture.colorSpace = THREE.SRGBColorSpace
+  texture.anisotropy = 4
+  return texture
+}
+
+export function monoFont(size: number, weight = 600) {
+  return `${weight} ${size}px ui-monospace, SFMono-Regular, Menlo, monospace`
+}
+
+/** Recursively disposes geometries, materials and their textures. */
+export function disposeObject(root: THREE.Object3D) {
+  root.traverse((object) => {
+    const mesh = object as Partial<THREE.Mesh> & Partial<THREE.Sprite>
+    if (mesh.geometry) mesh.geometry.dispose()
+    const material = mesh.material
+    if (!material) return
+    const list = Array.isArray(material) ? material : [material]
+    list.forEach((entry) => {
+      Object.values(entry).forEach((value) => {
+        if (value instanceof THREE.Texture) value.dispose()
+      })
+      entry.dispose()
+    })
+  })
+}
+
+/** Deterministic RNG so silkscreen art and instanced parts always match. */
+export function seededRandom(seed: number) {
+  let value = seed % 2147483647
+  if (value <= 0) value += 2147483646
+  return () => {
+    value = (value * 16807) % 2147483647
+    return (value - 1) / 2147483646
+  }
+}
+
+export function damp(current: number, target: number, lambda: number, dt: number) {
+  return current + (target - current) * (1 - Math.exp(-lambda * dt))
+}

--- a/components/machine/machine-core.ts
+++ b/components/machine/machine-core.ts
@@ -128,8 +128,8 @@ export function useWebglSupported(): boolean | null {
       setSupported(
         Boolean(
           canvas.getContext('webgl2') ||
-            canvas.getContext('webgl') ||
-            canvas.getContext('experimental-webgl')
+          canvas.getContext('webgl') ||
+          canvas.getContext('experimental-webgl')
         )
       )
     } catch {
@@ -187,6 +187,11 @@ export function seededRandom(seed: number) {
   }
 }
 
-export function damp(current: number, target: number, lambda: number, dt: number) {
+export function damp(
+  current: number,
+  target: number,
+  lambda: number,
+  dt: number
+) {
   return current + (target - current) * (1 - Math.exp(-lambda * dt))
 }

--- a/components/machine/rack-scene.module.css
+++ b/components/machine/rack-scene.module.css
@@ -1,0 +1,18 @@
+.host {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  touch-action: pan-y;
+}
+
+.canvas:focus-visible {
+  outline: 2px solid var(--mach-signal, #86f0d2);
+  outline-offset: -4px;
+}

--- a/components/machine/rack-scene.tsx
+++ b/components/machine/rack-scene.tsx
@@ -40,8 +40,10 @@ function drawFace(unit: RackUnit, theme: MachineTheme) {
   const palette = machinePalettes[theme]
   const metal = theme === 'dark' ? '#161d1f' : '#c9c6bd'
   const metalHi = theme === 'dark' ? '#222c2e' : '#e7e4da'
-  const ink = theme === 'dark' ? 'rgba(226, 240, 235, 0.94)' : 'rgba(24, 32, 30, 0.92)'
-  const inkFaint = theme === 'dark' ? 'rgba(226, 240, 235, 0.45)' : 'rgba(24, 32, 30, 0.5)'
+  const ink =
+    theme === 'dark' ? 'rgba(226, 240, 235, 0.94)' : 'rgba(24, 32, 30, 0.92)'
+  const inkFaint =
+    theme === 'dark' ? 'rgba(226, 240, 235, 0.45)' : 'rgba(24, 32, 30, 0.5)'
   return makeCanvasTexture(FACE_W, FACE_H, (ctx) => {
     const base = ctx.createLinearGradient(0, 0, 0, FACE_H)
     base.addColorStop(0, metalHi)
@@ -52,7 +54,9 @@ function drawFace(unit: RackUnit, theme: MachineTheme) {
 
     // brushed metal
     ctx.strokeStyle =
-      theme === 'dark' ? 'rgba(255, 255, 255, 0.035)' : 'rgba(255, 255, 255, 0.5)'
+      theme === 'dark'
+        ? 'rgba(255, 255, 255, 0.035)'
+        : 'rgba(255, 255, 255, 0.5)'
     ctx.lineWidth = 1
     for (let y = 0; y < FACE_H; y += 3) {
       ctx.beginPath()
@@ -62,7 +66,8 @@ function drawFace(unit: RackUnit, theme: MachineTheme) {
     }
 
     // rack ears + screws
-    ctx.fillStyle = theme === 'dark' ? 'rgba(0, 0, 0, 0.35)' : 'rgba(0, 0, 0, 0.14)'
+    ctx.fillStyle =
+      theme === 'dark' ? 'rgba(0, 0, 0, 0.35)' : 'rgba(0, 0, 0, 0.14)'
     ctx.fillRect(0, 0, 54, FACE_H)
     ctx.fillRect(FACE_W - 54, 0, 54, FACE_H)
     ;[
@@ -99,7 +104,11 @@ function drawFace(unit: RackUnit, theme: MachineTheme) {
     ctx.fillText(unit.face[0], 148, FACE_H / 2 - 16)
     ctx.fillStyle = inkFaint
     ctx.font = monoFont(19, 600)
-    ctx.fillText(`${unit.face[1]}  ·  ${unit.window.toUpperCase()}`, 148, FACE_H / 2 + 20)
+    ctx.fillText(
+      `${unit.face[1]}  ·  ${unit.window.toUpperCase()}`,
+      148,
+      FACE_H / 2 + 20
+    )
 
     // meter window
     const x0 = ((METER_X0 + UNIT_W / 2) / UNIT_W) * FACE_W
@@ -115,7 +124,8 @@ function drawFace(unit: RackUnit, theme: MachineTheme) {
     ctx.fillText(unit.meter.label.toUpperCase(), x0 - 10, 20)
 
     // ventilation slots
-    ctx.fillStyle = theme === 'dark' ? 'rgba(0, 0, 0, 0.5)' : 'rgba(0, 0, 0, 0.2)'
+    ctx.fillStyle =
+      theme === 'dark' ? 'rgba(0, 0, 0, 0.5)' : 'rgba(0, 0, 0, 0.2)'
     for (let index = 0; index < 6; index += 1) {
       ctx.fillRect(x1 + 42 + index * 12, 46, 5, FACE_H - 92)
     }
@@ -133,7 +143,12 @@ function radialTexture(color: string) {
   })
 }
 
-export function RackScene({ theme, activeId, onSelect, onHover }: RackSceneProps) {
+export function RackScene({
+  theme,
+  activeId,
+  onSelect,
+  onHover
+}: RackSceneProps) {
   const hostRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const activeRef = useRef(activeId)
@@ -190,7 +205,12 @@ export function RackScene({ theme, activeId, onSelect, onHover }: RackSceneProps
     shadowCamera.near = 1
     shadowCamera.far = 40
     scene.add(key)
-    const rim = new THREE.PointLight(palette.signal, theme === 'dark' ? 34 : 12, 30, 2)
+    const rim = new THREE.PointLight(
+      palette.signal,
+      theme === 'dark' ? 34 : 12,
+      30,
+      2
+    )
     rim.position.set(-6, 2, 5)
     scene.add(rim)
 
@@ -381,8 +401,7 @@ export function RackScene({ theme, activeId, onSelect, onHover }: RackSceneProps
     )
     rackUnits.forEach((_, unitIndex) => {
       for (let seg = 0; seg < SEGMENTS; seg += 1) {
-        const x =
-          METER_X0 + ((seg + 0.5) / SEGMENTS) * (METER_X1 - METER_X0)
+        const x = METER_X0 + ((seg + 0.5) / SEGMENTS) * (METER_X1 - METER_X0)
         dummy.position.set(x, unitCenterY(unitIndex), 0.36)
         dummy.rotation.set(0, 0, 0)
         dummy.updateMatrix()
@@ -404,8 +423,16 @@ export function RackScene({ theme, activeId, onSelect, onHover }: RackSceneProps
       material: THREE.MeshStandardMaterial
     }
     const cables: CableRig[] = patches.map((patch) => {
-      const a = new THREE.Vector3(UNIT_W / 2 - 0.55, unitCenterY(patch.fromIndex), 0.62)
-      const b = new THREE.Vector3(UNIT_W / 2 - 0.55, unitCenterY(patch.toIndex), 0.62)
+      const a = new THREE.Vector3(
+        UNIT_W / 2 - 0.55,
+        unitCenterY(patch.fromIndex),
+        0.62
+      )
+      const b = new THREE.Vector3(
+        UNIT_W / 2 - 0.55,
+        unitCenterY(patch.toIndex),
+        0.62
+      )
       const span = Math.abs(patch.toIndex - patch.fromIndex)
       const bow = 0.9 + span * 0.55
       const curve = new THREE.CatmullRomCurve3([
@@ -423,7 +450,10 @@ export function RackScene({ theme, activeId, onSelect, onHover }: RackSceneProps
         color: theme === 'dark' ? 0x24302f : 0x3d4744,
         roughness: 0.65
       })
-      const tube = new THREE.Mesh(new THREE.TubeGeometry(curve, 48, 0.055, 8, false), material)
+      const tube = new THREE.Mesh(
+        new THREE.TubeGeometry(curve, 48, 0.055, 8, false),
+        material
+      )
       tube.castShadow = true
       root.add(tube)
       return { from: patch.from, to: patch.to, curve, material }
@@ -477,9 +507,12 @@ export function RackScene({ theme, activeId, onSelect, onHover }: RackSceneProps
       camera.aspect = width / height
       const fitHeight = Math.max(
         (RACK_HEIGHT / 2) * 1.16,
-        (RACK_WIDTH / 2) * 1.06 / camera.aspect
+        ((RACK_WIDTH / 2) * 1.06) / camera.aspect
       )
-      state.radius = Math.min(40, fitHeight / Math.tan((camera.fov * Math.PI) / 360) + 1.2)
+      state.radius = Math.min(
+        40,
+        fitHeight / Math.tan((camera.fov * Math.PI) / 360) + 1.2
+      )
       camera.updateProjectionMatrix()
     }
 
@@ -517,9 +550,20 @@ export function RackScene({ theme, activeId, onSelect, onHover }: RackSceneProps
 
     const handleMove = (event: PointerEvent) => {
       if (state.dragging && pointerId === event.pointerId) {
-        moved = Math.max(moved, Math.hypot(event.clientX - downX, event.clientY - downY))
-        state.targetAzimuth = clamp(state.targetAzimuth + event.movementX * 0.004, -0.6, 0.6)
-        state.targetPolar = clamp(state.targetPolar - event.movementY * 0.003, -0.35, 0.45)
+        moved = Math.max(
+          moved,
+          Math.hypot(event.clientX - downX, event.clientY - downY)
+        )
+        state.targetAzimuth = clamp(
+          state.targetAzimuth + event.movementX * 0.004,
+          -0.6,
+          0.6
+        )
+        state.targetPolar = clamp(
+          state.targetPolar - event.movementY * 0.003,
+          -0.35,
+          0.45
+        )
         return
       }
       setHover(pick(event))
@@ -543,10 +587,14 @@ export function RackScene({ theme, activeId, onSelect, onHover }: RackSceneProps
 
     const handleKey = (event: KeyboardEvent) => {
       const step = 0.1
-      if (event.key === 'ArrowLeft') state.targetAzimuth = clamp(state.targetAzimuth - step, -0.6, 0.6)
-      else if (event.key === 'ArrowRight') state.targetAzimuth = clamp(state.targetAzimuth + step, -0.6, 0.6)
-      else if (event.key === 'ArrowUp') state.targetPolar = clamp(state.targetPolar + step, -0.35, 0.45)
-      else if (event.key === 'ArrowDown') state.targetPolar = clamp(state.targetPolar - step, -0.35, 0.45)
+      if (event.key === 'ArrowLeft')
+        state.targetAzimuth = clamp(state.targetAzimuth - step, -0.6, 0.6)
+      else if (event.key === 'ArrowRight')
+        state.targetAzimuth = clamp(state.targetAzimuth + step, -0.6, 0.6)
+      else if (event.key === 'ArrowUp')
+        state.targetPolar = clamp(state.targetPolar + step, -0.35, 0.45)
+      else if (event.key === 'ArrowDown')
+        state.targetPolar = clamp(state.targetPolar - step, -0.35, 0.45)
       else return
       event.preventDefault()
       state.idle = 0
@@ -577,7 +625,11 @@ export function RackScene({ theme, activeId, onSelect, onHover }: RackSceneProps
       state.idle += delta
 
       if (!state.dragging && state.idle > 7) {
-        state.targetAzimuth = clamp(-0.12 + Math.sin(elapsed * 0.1) * 0.16, -0.6, 0.6)
+        state.targetAzimuth = clamp(
+          -0.12 + Math.sin(elapsed * 0.1) * 0.16,
+          -0.6,
+          0.6
+        )
       }
       state.azimuth = damp(state.azimuth, state.targetAzimuth, 6, delta)
       state.polar = damp(state.polar, state.targetPolar, 6, delta)
@@ -596,7 +648,12 @@ export function RackScene({ theme, activeId, onSelect, onHover }: RackSceneProps
         const isHover = rig.unit.id === hovered
         rig.out = damp(rig.out, isActive ? 0.95 : isHover ? 0.28 : 0, 9, delta)
         rig.group.position.z = rig.out
-        rig.group.rotation.x = damp(rig.group.rotation.x, isActive ? -0.06 : 0, 8, delta)
+        rig.group.rotation.x = damp(
+          rig.group.rotation.x,
+          isActive ? -0.06 : 0,
+          8,
+          delta
+        )
 
         const goal = isActive ? 1 : 0.16
         rig.level = damp(rig.level, goal, isActive ? 2.4 : 6, delta)
@@ -612,13 +669,16 @@ export function RackScene({ theme, activeId, onSelect, onHover }: RackSceneProps
           ? meter.from + span * easeOut(Math.min(1, selectionAge / 1.4))
           : meter.from
         const ratio =
-          meter.to === 0 ? 0 : Math.min(1, Math.max(0, shown / Math.max(meter.to, 0.0001)))
+          meter.to === 0
+            ? 0
+            : Math.min(1, Math.max(0, shown / Math.max(meter.to, 0.0001)))
         const litCount = Math.round(ratio * SEGMENTS * (isActive ? 1 : 0.18))
         for (let seg = 0; seg < SEGMENTS; seg += 1) {
           const lit = seg < litCount
           const hot = seg > SEGMENTS * 0.78
           color.copy(lit ? (hot ? hotColor : litColor) : dimColor)
-          if (lit && isActive) color.multiplyScalar(1 + Math.sin(elapsed * 6 - seg) * 0.08)
+          if (lit && isActive)
+            color.multiplyScalar(1 + Math.sin(elapsed * 6 - seg) * 0.08)
           segments.setColorAt(index * SEGMENTS + seg, color)
           dummy.position.set(
             METER_X0 + ((seg + 0.5) / SEGMENTS) * (METER_X1 - METER_X0),
@@ -639,7 +699,9 @@ export function RackScene({ theme, activeId, onSelect, onHover }: RackSceneProps
       cables.forEach((cable) => {
         const live = cable.from === activeId2 || cable.to === activeId2
         cable.material.color.lerp(
-          live ? litColor : new THREE.Color(theme === 'dark' ? 0x24302f : 0x3d4744),
+          live
+            ? litColor
+            : new THREE.Color(theme === 'dark' ? 0x24302f : 0x3d4744),
           0.14
         )
       })
@@ -653,7 +715,8 @@ export function RackScene({ theme, activeId, onSelect, onHover }: RackSceneProps
         liveCables.forEach((cable, cableIndex) => {
           const forward = cable.from === activeId2
           for (let i = 0; i < perCable; i += 1) {
-            const phase = (elapsed * 0.42 + i / perCable + cableIndex * 0.17) % 1
+            const phase =
+              (elapsed * 0.42 + i / perCable + cableIndex * 0.17) % 1
             const t = forward ? phase : 1 - phase
             const point = cable.curve.getPoint(t)
             dummy.position.copy(point)
@@ -675,9 +738,14 @@ export function RackScene({ theme, activeId, onSelect, onHover }: RackSceneProps
 
       if (activeRig) {
         const rig = activeRig as UnitRig
-        glow.position.set(-UNIT_W / 2 + 0.42, unitCenterY(rig.index), rig.out + 0.5)
+        glow.position.set(
+          -UNIT_W / 2 + 0.42,
+          unitCenterY(rig.index),
+          rig.out + 0.5
+        )
         const strength = Math.max(0, 1 - selectionAge * 1.6)
-        ;(glow.material as THREE.SpriteMaterial).opacity = 0.15 + strength * 0.55
+        ;(glow.material as THREE.SpriteMaterial).opacity =
+          0.15 + strength * 0.55
         glow.scale.setScalar(2 + strength * 2)
       }
 

--- a/components/machine/rack-scene.tsx
+++ b/components/machine/rack-scene.tsx
@@ -1,0 +1,752 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import * as THREE from 'three'
+import {
+  RACK_HEIGHT,
+  RACK_WIDTH,
+  UNIT_PITCH,
+  patches,
+  rackUnits,
+  unitCenterY,
+  type RackUnit
+} from '@/app/career/career-data'
+import {
+  damp,
+  disposeObject,
+  machinePalettes,
+  makeCanvasTexture,
+  monoFont,
+  type MachineTheme
+} from './machine-core'
+import styles from './rack-scene.module.css'
+
+type RackSceneProps = {
+  theme: MachineTheme
+  activeId: string
+  onSelect: (id: string) => void
+  onHover: (id: string | null) => void
+}
+
+const FACE_W = 1024
+const FACE_H = 150
+const SEGMENTS = 20
+const UNIT_W = 10.9
+const UNIT_H = UNIT_PITCH - 0.12
+const METER_X0 = 0.9
+const METER_X1 = 3.5
+
+function drawFace(unit: RackUnit, theme: MachineTheme) {
+  const palette = machinePalettes[theme]
+  const metal = theme === 'dark' ? '#161d1f' : '#c9c6bd'
+  const metalHi = theme === 'dark' ? '#222c2e' : '#e7e4da'
+  const ink = theme === 'dark' ? 'rgba(226, 240, 235, 0.94)' : 'rgba(24, 32, 30, 0.92)'
+  const inkFaint = theme === 'dark' ? 'rgba(226, 240, 235, 0.45)' : 'rgba(24, 32, 30, 0.5)'
+  return makeCanvasTexture(FACE_W, FACE_H, (ctx) => {
+    const base = ctx.createLinearGradient(0, 0, 0, FACE_H)
+    base.addColorStop(0, metalHi)
+    base.addColorStop(0.5, metal)
+    base.addColorStop(1, theme === 'dark' ? '#10171a' : '#b8b5ac')
+    ctx.fillStyle = base
+    ctx.fillRect(0, 0, FACE_W, FACE_H)
+
+    // brushed metal
+    ctx.strokeStyle =
+      theme === 'dark' ? 'rgba(255, 255, 255, 0.035)' : 'rgba(255, 255, 255, 0.5)'
+    ctx.lineWidth = 1
+    for (let y = 0; y < FACE_H; y += 3) {
+      ctx.beginPath()
+      ctx.moveTo(0, y + 0.5)
+      ctx.lineTo(FACE_W, y + 0.5)
+      ctx.stroke()
+    }
+
+    // rack ears + screws
+    ctx.fillStyle = theme === 'dark' ? 'rgba(0, 0, 0, 0.35)' : 'rgba(0, 0, 0, 0.14)'
+    ctx.fillRect(0, 0, 54, FACE_H)
+    ctx.fillRect(FACE_W - 54, 0, 54, FACE_H)
+    ;[
+      [27, 36],
+      [27, FACE_H - 36],
+      [FACE_W - 27, 36],
+      [FACE_W - 27, FACE_H - 36]
+    ].forEach(([cx, cy]) => {
+      ctx.beginPath()
+      ctx.arc(cx, cy, 11, 0, Math.PI * 2)
+      ctx.fillStyle = theme === 'dark' ? '#0a1113' : '#8f8d85'
+      ctx.fill()
+      ctx.strokeStyle = inkFaint
+      ctx.lineWidth = 2
+      ctx.stroke()
+      ctx.beginPath()
+      ctx.moveTo(cx - 6, cy - 6)
+      ctx.lineTo(cx + 6, cy + 6)
+      ctx.strokeStyle = ink
+      ctx.lineWidth = 2.5
+      ctx.stroke()
+    })
+
+    // slot number
+    ctx.fillStyle = palette.signalCss
+    ctx.font = monoFont(46, 700)
+    ctx.textBaseline = 'middle'
+    ctx.textAlign = 'left'
+    ctx.fillText(unit.slot, 74, FACE_H / 2)
+
+    // engraved label
+    ctx.fillStyle = ink
+    ctx.font = monoFont(30, 700)
+    ctx.fillText(unit.face[0], 148, FACE_H / 2 - 16)
+    ctx.fillStyle = inkFaint
+    ctx.font = monoFont(19, 600)
+    ctx.fillText(`${unit.face[1]}  ·  ${unit.window.toUpperCase()}`, 148, FACE_H / 2 + 20)
+
+    // meter window
+    const x0 = ((METER_X0 + UNIT_W / 2) / UNIT_W) * FACE_W
+    const x1 = ((METER_X1 + UNIT_W / 2) / UNIT_W) * FACE_W
+    ctx.fillStyle = theme === 'dark' ? '#05100e' : '#0a1614'
+    ctx.fillRect(x0 - 10, 34, x1 - x0 + 20, FACE_H - 68)
+    ctx.strokeStyle = inkFaint
+    ctx.lineWidth = 2
+    ctx.strokeRect(x0 - 10, 34, x1 - x0 + 20, FACE_H - 68)
+    ctx.fillStyle = inkFaint
+    ctx.font = monoFont(15, 600)
+    ctx.textAlign = 'left'
+    ctx.fillText(unit.meter.label.toUpperCase(), x0 - 10, 20)
+
+    // ventilation slots
+    ctx.fillStyle = theme === 'dark' ? 'rgba(0, 0, 0, 0.5)' : 'rgba(0, 0, 0, 0.2)'
+    for (let index = 0; index < 6; index += 1) {
+      ctx.fillRect(x1 + 42 + index * 12, 46, 5, FACE_H - 92)
+    }
+  })
+}
+
+function radialTexture(color: string) {
+  return makeCanvasTexture(128, 128, (ctx) => {
+    const gradient = ctx.createRadialGradient(64, 64, 0, 64, 64, 64)
+    gradient.addColorStop(0, color)
+    gradient.addColorStop(0.3, color)
+    gradient.addColorStop(1, 'rgba(0, 0, 0, 0)')
+    ctx.fillStyle = gradient
+    ctx.fillRect(0, 0, 128, 128)
+  })
+}
+
+export function RackScene({ theme, activeId, onSelect, onHover }: RackSceneProps) {
+  const hostRef = useRef<HTMLDivElement>(null)
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const activeRef = useRef(activeId)
+  const selectRef = useRef(onSelect)
+  const hoverRef = useRef(onHover)
+
+  useEffect(() => {
+    selectRef.current = onSelect
+    hoverRef.current = onHover
+  }, [onSelect, onHover])
+
+  useEffect(() => {
+    activeRef.current = activeId
+  }, [activeId])
+
+  useEffect(() => {
+    const host = hostRef.current
+    const canvas = canvasRef.current
+    if (!host || !canvas) return
+
+    const palette = machinePalettes[theme]
+    let renderer: THREE.WebGLRenderer
+    try {
+      renderer = new THREE.WebGLRenderer({ canvas, antialias: true })
+    } catch {
+      return
+    }
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 1.75))
+    renderer.setClearColor(palette.clear, 1)
+    renderer.outputColorSpace = THREE.SRGBColorSpace
+    renderer.shadowMap.enabled = true
+    renderer.shadowMap.type = THREE.PCFSoftShadowMap
+
+    const scene = new THREE.Scene()
+    scene.background = new THREE.Color(palette.clear)
+    const camera = new THREE.PerspectiveCamera(36, 1, 0.5, 120)
+
+    scene.add(
+      new THREE.HemisphereLight(
+        theme === 'dark' ? 0x8fd8cc : 0xffffff,
+        theme === 'dark' ? 0x0a1416 : 0xa9a196,
+        theme === 'dark' ? 0.75 : 1.4
+      )
+    )
+    const key = new THREE.DirectionalLight(0xffffff, theme === 'dark' ? 2 : 2.6)
+    key.position.set(5, 8, 12)
+    key.castShadow = true
+    key.shadow.mapSize.set(1024, 1024)
+    const shadowCamera = key.shadow.camera as THREE.OrthographicCamera
+    shadowCamera.left = -9
+    shadowCamera.right = 9
+    shadowCamera.top = 7
+    shadowCamera.bottom = -7
+    shadowCamera.near = 1
+    shadowCamera.far = 40
+    scene.add(key)
+    const rim = new THREE.PointLight(palette.signal, theme === 'dark' ? 34 : 12, 30, 2)
+    rim.position.set(-6, 2, 5)
+    scene.add(rim)
+
+    const root = new THREE.Group()
+    scene.add(root)
+
+    // ---- rack frame -------------------------------------------------------
+    const frameMaterial = new THREE.MeshStandardMaterial({
+      color: theme === 'dark' ? 0x0d1416 : 0x76736c,
+      roughness: 0.55,
+      metalness: 0.65
+    })
+    const railGeometry = new THREE.BoxGeometry(0.55, RACK_HEIGHT + 1.1, 1.6)
+    ;[-1, 1].forEach((side) => {
+      const rail = new THREE.Mesh(railGeometry, frameMaterial)
+      rail.position.set((side * RACK_WIDTH) / 2 - side * 0.28, 0, -0.35)
+      rail.castShadow = true
+      rail.receiveShadow = true
+      root.add(rail)
+    })
+    const capGeometry = new THREE.BoxGeometry(RACK_WIDTH, 0.5, 1.6)
+    ;[-1, 1].forEach((side) => {
+      const cap = new THREE.Mesh(capGeometry, frameMaterial)
+      cap.position.set(0, (side * (RACK_HEIGHT + 1.1)) / 2 - side * 0.25, -0.35)
+      cap.castShadow = true
+      root.add(cap)
+    })
+    const backPlane = new THREE.Mesh(
+      new THREE.PlaneGeometry(RACK_WIDTH, RACK_HEIGHT + 1.1),
+      new THREE.MeshStandardMaterial({
+        color: theme === 'dark' ? 0x05090a : 0x4c4a45,
+        roughness: 0.95
+      })
+    )
+    backPlane.position.z = -1.1
+    backPlane.receiveShadow = true
+    root.add(backPlane)
+
+    // ---- mounting holes (instanced) --------------------------------------
+    const holeGeometry = new THREE.CylinderGeometry(0.055, 0.055, 0.12, 8)
+    const holeMaterial = new THREE.MeshStandardMaterial({
+      color: 0x05090a,
+      roughness: 0.9
+    })
+    const holeCount = 2 * 3 * rackUnits.length
+    const holes = new THREE.InstancedMesh(holeGeometry, holeMaterial, holeCount)
+    const dummy = new THREE.Object3D()
+    let holeIndex = 0
+    rackUnits.forEach((_, index) => {
+      const cy = unitCenterY(index)
+      ;[-1, 1].forEach((side) => {
+        ;[-0.3, 0, 0.3].forEach((offset) => {
+          dummy.position.set(
+            (side * RACK_WIDTH) / 2 - side * 0.28,
+            cy + offset * UNIT_PITCH,
+            0.46
+          )
+          dummy.rotation.set(Math.PI / 2, 0, 0)
+          dummy.updateMatrix()
+          holes.setMatrixAt(holeIndex, dummy.matrix)
+          holeIndex += 1
+        })
+      })
+    })
+    holes.instanceMatrix.needsUpdate = true
+    root.add(holes)
+
+    // ---- units ------------------------------------------------------------
+    type UnitRig = {
+      unit: RackUnit
+      index: number
+      group: THREE.Group
+      out: number
+      level: number
+      ledMaterial: THREE.MeshStandardMaterial
+      jack: THREE.Vector3
+    }
+
+    const rigs: UnitRig[] = []
+    const clickable: THREE.Object3D[] = []
+    const unitGeometry = new THREE.BoxGeometry(UNIT_W, UNIT_H, 0.62)
+    const sideMaterial = new THREE.MeshStandardMaterial({
+      color: theme === 'dark' ? 0x0f1618 : 0x8e8b83,
+      roughness: 0.6,
+      metalness: 0.5
+    })
+    const goldMaterial = new THREE.MeshStandardMaterial({
+      color: palette.gold,
+      roughness: 0.25,
+      metalness: 0.95
+    })
+    const jackGeometry = new THREE.CylinderGeometry(0.13, 0.15, 0.16, 14)
+    const jackHoleGeometry = new THREE.CylinderGeometry(0.06, 0.06, 0.2, 10)
+    const ledGeometry = new THREE.CylinderGeometry(0.055, 0.055, 0.1, 10)
+    const knobGeometry = new THREE.CylinderGeometry(0.2, 0.22, 0.22, 18)
+
+    rackUnits.forEach((unit, index) => {
+      const group = new THREE.Group()
+      group.position.set(0, unitCenterY(index), 0)
+      root.add(group)
+
+      const faceMaterial = new THREE.MeshStandardMaterial({
+        map: drawFace(unit, theme),
+        roughness: 0.45,
+        metalness: 0.55
+      })
+      const body = new THREE.Mesh(unitGeometry, [
+        sideMaterial,
+        sideMaterial,
+        sideMaterial,
+        sideMaterial,
+        faceMaterial,
+        sideMaterial
+      ])
+      body.castShadow = true
+      body.receiveShadow = true
+      body.userData.unitId = unit.id
+      group.add(body)
+      clickable.push(body)
+
+      // status LED
+      const ledMaterial = new THREE.MeshStandardMaterial({
+        color: palette.signal,
+        emissive: new THREE.Color(palette.signal),
+        emissiveIntensity: 0.2,
+        roughness: 0.3
+      })
+      const led = new THREE.Mesh(ledGeometry, ledMaterial)
+      led.rotation.x = Math.PI / 2
+      led.position.set(-UNIT_W / 2 + 0.42, UNIT_H / 2 - 0.2, 0.34)
+      group.add(led)
+
+      // patch jack + knob
+      const jack = new THREE.Mesh(jackGeometry, goldMaterial)
+      jack.rotation.x = Math.PI / 2
+      jack.position.set(UNIT_W / 2 - 0.55, 0, 0.36)
+      group.add(jack)
+      const jackHole = new THREE.Mesh(
+        jackHoleGeometry,
+        new THREE.MeshStandardMaterial({ color: 0x04090a, roughness: 1 })
+      )
+      jackHole.rotation.x = Math.PI / 2
+      jackHole.position.set(UNIT_W / 2 - 0.55, 0, 0.42)
+      group.add(jackHole)
+
+      const knob = new THREE.Mesh(
+        knobGeometry,
+        new THREE.MeshStandardMaterial({
+          color: theme === 'dark' ? 0x1b2325 : 0x3a3f3d,
+          roughness: 0.45,
+          metalness: 0.4
+        })
+      )
+      knob.rotation.x = Math.PI / 2
+      knob.position.set(UNIT_W / 2 - 1.25, 0, 0.36)
+      knob.rotation.y = index * 0.7
+      group.add(knob)
+
+      rigs.push({
+        unit,
+        index,
+        group,
+        out: 0,
+        level: 0,
+        ledMaterial,
+        jack: new THREE.Vector3(UNIT_W / 2 - 0.55, unitCenterY(index), 0.45)
+      })
+    })
+
+    // ---- meters (one instanced mesh for every segment) --------------------
+    const segmentGeometry = new THREE.BoxGeometry(
+      ((METER_X1 - METER_X0) / SEGMENTS) * 0.72,
+      UNIT_H * 0.42,
+      0.08
+    )
+    const segmentMaterial = new THREE.MeshStandardMaterial({
+      roughness: 0.4,
+      emissiveIntensity: 1
+    })
+    const segments = new THREE.InstancedMesh(
+      segmentGeometry,
+      segmentMaterial,
+      rackUnits.length * SEGMENTS
+    )
+    segments.instanceColor = new THREE.InstancedBufferAttribute(
+      new Float32Array(rackUnits.length * SEGMENTS * 3),
+      3
+    )
+    rackUnits.forEach((_, unitIndex) => {
+      for (let seg = 0; seg < SEGMENTS; seg += 1) {
+        const x =
+          METER_X0 + ((seg + 0.5) / SEGMENTS) * (METER_X1 - METER_X0)
+        dummy.position.set(x, unitCenterY(unitIndex), 0.36)
+        dummy.rotation.set(0, 0, 0)
+        dummy.updateMatrix()
+        segments.setMatrixAt(unitIndex * SEGMENTS + seg, dummy.matrix)
+      }
+    })
+    segments.instanceMatrix.needsUpdate = true
+    root.add(segments)
+
+    const dimColor = new THREE.Color(theme === 'dark' ? 0x123028 : 0x14352c)
+    const litColor = new THREE.Color(palette.signal)
+    const hotColor = new THREE.Color(palette.warn)
+
+    // ---- patch cables -----------------------------------------------------
+    type CableRig = {
+      from: string
+      to: string
+      curve: THREE.CatmullRomCurve3
+      material: THREE.MeshStandardMaterial
+    }
+    const cables: CableRig[] = patches.map((patch) => {
+      const a = new THREE.Vector3(UNIT_W / 2 - 0.55, unitCenterY(patch.fromIndex), 0.62)
+      const b = new THREE.Vector3(UNIT_W / 2 - 0.55, unitCenterY(patch.toIndex), 0.62)
+      const span = Math.abs(patch.toIndex - patch.fromIndex)
+      const bow = 0.9 + span * 0.55
+      const curve = new THREE.CatmullRomCurve3([
+        a,
+        new THREE.Vector3(a.x + bow * 0.55, a.y - 0.25, a.z + bow),
+        new THREE.Vector3(
+          a.x + bow * 0.7,
+          (a.y + b.y) / 2 - 0.35 * span,
+          a.z + bow * 1.15
+        ),
+        new THREE.Vector3(b.x + bow * 0.55, b.y + 0.25, b.z + bow),
+        b
+      ])
+      const material = new THREE.MeshStandardMaterial({
+        color: theme === 'dark' ? 0x24302f : 0x3d4744,
+        roughness: 0.65
+      })
+      const tube = new THREE.Mesh(new THREE.TubeGeometry(curve, 48, 0.055, 8, false), material)
+      tube.castShadow = true
+      root.add(tube)
+      return { from: patch.from, to: patch.to, curve, material }
+    })
+
+    // ---- traffic dots (instanced) -----------------------------------------
+    const DOTS = 72
+    const dotMesh = new THREE.InstancedMesh(
+      new THREE.SphereGeometry(0.085, 8, 8),
+      new THREE.MeshBasicMaterial({ color: palette.signal }),
+      DOTS
+    )
+    dotMesh.frustumCulled = false
+    root.add(dotMesh)
+
+    const glowTexture = radialTexture(palette.copperLit)
+    const glow = new THREE.Sprite(
+      new THREE.SpriteMaterial({
+        map: glowTexture,
+        transparent: true,
+        depthWrite: false,
+        blending: THREE.AdditiveBlending,
+        opacity: 0
+      })
+    )
+    glow.scale.setScalar(3)
+    root.add(glow)
+
+    // ---- interaction ------------------------------------------------------
+    const state = {
+      azimuth: -0.12,
+      polar: 0.05,
+      targetAzimuth: -0.12,
+      targetPolar: 0.05,
+      radius: 20,
+      dragging: false,
+      idle: 0
+    }
+    const raycaster = new THREE.Raycaster()
+    const pointer = new THREE.Vector2()
+    const target = new THREE.Vector3(0, 0, 0)
+    let hovered: string | null = null
+    let selectionAge = 99
+    let lastActive = activeRef.current
+
+    const resize = () => {
+      const width = host.clientWidth
+      const height = host.clientHeight
+      if (!width || !height) return
+      renderer.setSize(width, height, false)
+      camera.aspect = width / height
+      const fitHeight = Math.max(
+        (RACK_HEIGHT / 2) * 1.16,
+        (RACK_WIDTH / 2) * 1.06 / camera.aspect
+      )
+      state.radius = Math.min(40, fitHeight / Math.tan((camera.fov * Math.PI) / 360) + 1.2)
+      camera.updateProjectionMatrix()
+    }
+
+    const setHover = (id: string | null) => {
+      if (hovered === id) return
+      hovered = id
+      canvas.style.cursor = id ? 'pointer' : 'grab'
+      hoverRef.current(id)
+    }
+
+    const pick = (event: PointerEvent) => {
+      const bounds = canvas.getBoundingClientRect()
+      pointer.x = ((event.clientX - bounds.left) / bounds.width) * 2 - 1
+      pointer.y = -((event.clientY - bounds.top) / bounds.height) * 2 + 1
+      raycaster.setFromCamera(pointer, camera)
+      const hit = raycaster.intersectObjects(clickable, false)[0]
+      return (hit?.object.userData.unitId as string | undefined) ?? null
+    }
+
+    let pointerId: number | null = null
+    let downX = 0
+    let downY = 0
+    let moved = 0
+
+    const handleDown = (event: PointerEvent) => {
+      pointerId = event.pointerId
+      downX = event.clientX
+      downY = event.clientY
+      moved = 0
+      state.dragging = true
+      state.idle = 0
+      canvas.setPointerCapture(event.pointerId)
+      canvas.style.cursor = 'grabbing'
+    }
+
+    const handleMove = (event: PointerEvent) => {
+      if (state.dragging && pointerId === event.pointerId) {
+        moved = Math.max(moved, Math.hypot(event.clientX - downX, event.clientY - downY))
+        state.targetAzimuth = clamp(state.targetAzimuth + event.movementX * 0.004, -0.6, 0.6)
+        state.targetPolar = clamp(state.targetPolar - event.movementY * 0.003, -0.35, 0.45)
+        return
+      }
+      setHover(pick(event))
+      state.idle = 0
+    }
+
+    const handleUp = (event: PointerEvent) => {
+      if (pointerId !== event.pointerId) return
+      state.dragging = false
+      pointerId = null
+      canvas.releasePointerCapture?.(event.pointerId)
+      canvas.style.cursor = hovered ? 'pointer' : 'grab'
+      if (moved < 6) {
+        const id = pick(event)
+        if (id) {
+          selectRef.current(id)
+          selectionAge = 0
+        }
+      }
+    }
+
+    const handleKey = (event: KeyboardEvent) => {
+      const step = 0.1
+      if (event.key === 'ArrowLeft') state.targetAzimuth = clamp(state.targetAzimuth - step, -0.6, 0.6)
+      else if (event.key === 'ArrowRight') state.targetAzimuth = clamp(state.targetAzimuth + step, -0.6, 0.6)
+      else if (event.key === 'ArrowUp') state.targetPolar = clamp(state.targetPolar + step, -0.35, 0.45)
+      else if (event.key === 'ArrowDown') state.targetPolar = clamp(state.targetPolar - step, -0.35, 0.45)
+      else return
+      event.preventDefault()
+      state.idle = 0
+    }
+
+    canvas.addEventListener('pointerdown', handleDown)
+    canvas.addEventListener('pointermove', handleMove)
+    canvas.addEventListener('pointerup', handleUp)
+    canvas.addEventListener('pointercancel', handleUp)
+    canvas.addEventListener('pointerleave', () => setHover(null))
+    canvas.addEventListener('keydown', handleKey)
+    canvas.style.cursor = 'grab'
+
+    const clock = new THREE.Clock()
+    let frame = 0
+    let inView = true
+    let visible = !document.hidden
+    const color = new THREE.Color()
+
+    const renderFrame = () => {
+      const delta = Math.min(clock.getDelta(), 0.05)
+      const elapsed = clock.elapsedTime
+      if (activeRef.current !== lastActive) {
+        lastActive = activeRef.current
+        selectionAge = 0
+      }
+      selectionAge += delta
+      state.idle += delta
+
+      if (!state.dragging && state.idle > 7) {
+        state.targetAzimuth = clamp(-0.12 + Math.sin(elapsed * 0.1) * 0.16, -0.6, 0.6)
+      }
+      state.azimuth = damp(state.azimuth, state.targetAzimuth, 6, delta)
+      state.polar = damp(state.polar, state.targetPolar, 6, delta)
+      camera.position.set(
+        state.radius * Math.sin(state.azimuth),
+        state.radius * Math.sin(state.polar),
+        state.radius * Math.cos(state.azimuth) * Math.cos(state.polar)
+      )
+      camera.lookAt(target)
+
+      const activeId2 = activeRef.current
+      let activeRig: UnitRig | null = null
+
+      rigs.forEach((rig, index) => {
+        const isActive = rig.unit.id === activeId2
+        const isHover = rig.unit.id === hovered
+        rig.out = damp(rig.out, isActive ? 0.95 : isHover ? 0.28 : 0, 9, delta)
+        rig.group.position.z = rig.out
+        rig.group.rotation.x = damp(rig.group.rotation.x, isActive ? -0.06 : 0, 8, delta)
+
+        const goal = isActive ? 1 : 0.16
+        rig.level = damp(rig.level, goal, isActive ? 2.4 : 6, delta)
+        rig.ledMaterial.emissiveIntensity = isActive
+          ? 1.6 + Math.sin(elapsed * 5) * 0.4
+          : isHover
+            ? 0.9
+            : 0.18
+
+        const meter = rig.unit.meter
+        const span = meter.to - meter.from
+        const shown = isActive
+          ? meter.from + span * easeOut(Math.min(1, selectionAge / 1.4))
+          : meter.from
+        const ratio =
+          meter.to === 0 ? 0 : Math.min(1, Math.max(0, shown / Math.max(meter.to, 0.0001)))
+        const litCount = Math.round(ratio * SEGMENTS * (isActive ? 1 : 0.18))
+        for (let seg = 0; seg < SEGMENTS; seg += 1) {
+          const lit = seg < litCount
+          const hot = seg > SEGMENTS * 0.78
+          color.copy(lit ? (hot ? hotColor : litColor) : dimColor)
+          if (lit && isActive) color.multiplyScalar(1 + Math.sin(elapsed * 6 - seg) * 0.08)
+          segments.setColorAt(index * SEGMENTS + seg, color)
+          dummy.position.set(
+            METER_X0 + ((seg + 0.5) / SEGMENTS) * (METER_X1 - METER_X0),
+            unitCenterY(index) + rig.out * 0.06,
+            0.36 + rig.out
+          )
+          dummy.rotation.set(0, 0, 0)
+          dummy.scale.setScalar(1)
+          dummy.updateMatrix()
+          segments.setMatrixAt(index * SEGMENTS + seg, dummy.matrix)
+        }
+        if (isActive) activeRig = rig
+      })
+      if (segments.instanceColor) segments.instanceColor.needsUpdate = true
+      segments.instanceMatrix.needsUpdate = true
+
+      // cables: light the ones touching the active unit
+      cables.forEach((cable) => {
+        const live = cable.from === activeId2 || cable.to === activeId2
+        cable.material.color.lerp(
+          live ? litColor : new THREE.Color(theme === 'dark' ? 0x24302f : 0x3d4744),
+          0.14
+        )
+      })
+
+      const liveCables = cables.filter(
+        (cable) => cable.from === activeId2 || cable.to === activeId2
+      )
+      let dotIndex = 0
+      if (liveCables.length) {
+        const perCable = Math.floor(DOTS / liveCables.length)
+        liveCables.forEach((cable, cableIndex) => {
+          const forward = cable.from === activeId2
+          for (let i = 0; i < perCable; i += 1) {
+            const phase = (elapsed * 0.42 + i / perCable + cableIndex * 0.17) % 1
+            const t = forward ? phase : 1 - phase
+            const point = cable.curve.getPoint(t)
+            dummy.position.copy(point)
+            dummy.rotation.set(0, 0, 0)
+            dummy.scale.setScalar(0.6 + Math.sin(phase * Math.PI) * 0.8)
+            dummy.updateMatrix()
+            dotMesh.setMatrixAt(dotIndex, dummy.matrix)
+            dotIndex += 1
+          }
+        })
+      }
+      for (let i = dotIndex; i < DOTS; i += 1) {
+        dummy.position.set(0, 0, -60)
+        dummy.scale.setScalar(0.001)
+        dummy.updateMatrix()
+        dotMesh.setMatrixAt(i, dummy.matrix)
+      }
+      dotMesh.instanceMatrix.needsUpdate = true
+
+      if (activeRig) {
+        const rig = activeRig as UnitRig
+        glow.position.set(-UNIT_W / 2 + 0.42, unitCenterY(rig.index), rig.out + 0.5)
+        const strength = Math.max(0, 1 - selectionAge * 1.6)
+        ;(glow.material as THREE.SpriteMaterial).opacity = 0.15 + strength * 0.55
+        glow.scale.setScalar(2 + strength * 2)
+      }
+
+      renderer.render(scene, camera)
+    }
+
+    const animate = () => {
+      renderFrame()
+      frame = window.requestAnimationFrame(animate)
+    }
+    const sync = () => {
+      window.cancelAnimationFrame(frame)
+      if (inView && visible) {
+        clock.getDelta()
+        frame = window.requestAnimationFrame(animate)
+      }
+    }
+
+    const resizeObserver = new ResizeObserver(resize)
+    resizeObserver.observe(host)
+    const intersection = new IntersectionObserver(
+      ([entry]) => {
+        inView = entry.isIntersecting
+        sync()
+      },
+      { threshold: 0.02 }
+    )
+    intersection.observe(host)
+    const handleVisibility = () => {
+      visible = !document.hidden
+      sync()
+    }
+    document.addEventListener('visibilitychange', handleVisibility)
+
+    resize()
+    sync()
+
+    return () => {
+      window.cancelAnimationFrame(frame)
+      resizeObserver.disconnect()
+      intersection.disconnect()
+      document.removeEventListener('visibilitychange', handleVisibility)
+      canvas.removeEventListener('pointerdown', handleDown)
+      canvas.removeEventListener('pointermove', handleMove)
+      canvas.removeEventListener('pointerup', handleUp)
+      canvas.removeEventListener('pointercancel', handleUp)
+      canvas.removeEventListener('keydown', handleKey)
+      disposeObject(scene)
+      renderer.dispose()
+    }
+  }, [theme])
+
+  return (
+    <div ref={hostRef} className={styles.host}>
+      <canvas
+        ref={canvasRef}
+        className={styles.canvas}
+        tabIndex={0}
+        role="application"
+        aria-label="Interactive equipment rack. Drag to tilt, arrow keys to rotate, click a rack unit to pull it out and read it. The same information is listed in the slot buttons and the plain-text log below."
+      />
+    </div>
+  )
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max)
+}
+
+function easeOut(t: number) {
+  return 1 - Math.pow(1 - t, 3)
+}

--- a/components/machine/rack-scene.tsx
+++ b/components/machine/rack-scene.tsx
@@ -506,7 +506,7 @@ export function RackScene({
       renderer.setSize(width, height, false)
       camera.aspect = width / height
       const fitHeight = Math.max(
-        (RACK_HEIGHT / 2) * 1.16,
+        (RACK_HEIGHT / 2) * 1.07,
         ((RACK_WIDTH / 2) * 1.06) / camera.aspect
       )
       state.radius = Math.min(


### PR DESCRIPTION
## Option 2 of 3 — "The Machine"

**A creative experiment.** Both pages are physical instruments you operate — the 3D *is* the content rather than wallpaper behind it.

### /career — a 19" equipment rack
Nine rack units, one per real chapter, each with a front-panel LED bargraph carrying its actual number. Click a unit and it slides out of the chassis with a mechanical detent while the meter **counts from the before-number to the after-number** — 1M → 15M users, &lt;$1M → $5M/day, 0 → 7 years at one firm — and its patch cables light up with traffic.

`01 HALLER` → `02 TURING SCHOOL` → `03 STELLAR ELEMENTS` → `04 APPLE / CHATBOT` → `05 CHICK-FIL-A` → `06 APPLE / CLOUD UI` (solo, 2 years) → `07 APPLE / PORTAL` → patch field → output.

### /systems — a playable cutaway
The same machine in cross-section: a third-party delivery order crossing **edge → service → data → runtime → feedback**. Run / Step / 0.5–4× rate / cutaway depth slider, plus **fault injection per stage** — packets stall, the breaker opens, a degraded path engages, and a scope-style event log narrates the incident in timestamped lines (`ERR` → `WARN breaker OPEN` → `INFO degraded path` → `OK rejoined` → `DONE`).

It is the Chick-fil-A architecture, made playable. You learn what he actually did by breaking it.

### Technical
- Instanced geometry, capped DPR, paused when offscreen, disposed on unmount.
- **Full-parity static fallbacks** for reduced-motion and no-WebGL: an SVG rack elevation with working meters, and an SVG cross-section diagram, both driving the same readout panels. Status LEDs are honest about when the fallback is showing.
- Verified at 390 / 1440 in both themes plus the reduced-motion path.

---

## Shared context across all three PRs

These three branches are **competing alternatives**, all forked from `codex/refine-portfolio-experiences` at `0785351`. Pick one; the other two can be closed.

### The premise fix
The previous pages framed the Apple and Chick-fil-A engagements as **embedded engineering** and made "embedded systems" the career through-line. Per Devon's own résumés, that is not accurate — both were backend / full-stack platform and third-party integration work at consumer scale. Every branch strips that framing.

### The story that was missing
Apple is not a single 2018–2020 engagement. It is a **seven-year relationship across three eras**, under one firm — Stellar Elements (formerly Big Nerd Ranch), an Amdocs company, July 2018 → present:

| Period | Engagement | Role |
| --- | --- | --- |
| 2024 → present | Apple — internal cloud site → developer portal | Product engineer, React + TypeScript |
| 2022 → 2024 | Apple — third-party cloud resource UI | **Sole engineer, two years** |
| 2020 → 2022 | Chick-fil-A — third-party delivery (DoorDash/UberEats/Grubhub) | Project engineering lead |
| 2018 → 2020 | Apple — chatbot platform | Backend lead |

Verified numbers now used as content: 1M → 15M users at 100% uptime · 60s → 2s page load · Node 5 → 12 · Angular 1 → Vue · &lt;$1M → $5M per day through Covid · ~10% higher AOV from UberEats combo meals · AWS CloudFormation migration.

Positioning target: **Product Engineer**.

### Known repo issues found (pre-existing, NOT introduced here)
- `app/layout.tsx` hardcodes `<html className="dark">` and never mounts `ThemeProvider`, so **light mode is unreachable site-wide** even though `next-themes` is installed. All three branches author and verify light mode anyway, so it works as soon as the toggle is wired.
- `npx eslint` fails repo-wide on an `eslint-config-next` ↔ `zod` exports conflict, so lint is currently a no-op. Reproduces on untouched files.

### Still open before publishing
- Exact start/end **months** for the two recent Apple eras.
- **Current title** — pages still carry "Solutions Architect" from the 2022 résumé.
- `/resume.pdf` is linked but the asset does not exist yet.

Untouched: `/orbital`, `/blog`, `/directions`. `npx contentlayer2 build && npx next build` passes on every branch.
