### PR TITLE
Career + Systems redesign — Option 3: "Signal" (WebGL feedback-field, typography as emitter)

### DIFF
--- a/app/career/career-experience.tsx
+++ b/app/career/career-experience.tsx
@@ -21,8 +21,8 @@ type Transmission = {
   readout: { k: string; v: string }[]
 }
 
-// TODO(devon): the résumé on file ends in 2022. Confirm current title and any
-// client work since the Chick-fil-A engagement, then add a sixth transmission.
+// TODO(devon): exact start/end months for the two most recent Apple eras, and
+// the current title (the résumé on file says Solutions Architect, 2022).
 const transmissions: Transmission[] = [
   {
     id: 'haller',
@@ -43,29 +43,11 @@ const transmissions: Transmission[] = [
     ]
   },
   {
-    id: 'firm',
+    id: 'apple-chatbot',
     index: '01',
-    word: 'BIG NERD RANCH',
-    caption: 'transmission 01',
-    kicker: 'The arc · since 2018',
-    title: 'One firm since 2018. Big Nerd Ranch, Solutions Architect.',
-    body: [
-      'My whole engineering career has been with a single consulting firm, which means an unusual number of first days. You land in a codebase you did not write, beside a team that already made its decisions, against a deadline that predates you. Being useful in week one and trusted by week four is the actual skill — the languages are the easy part.',
-      'It also means my work gets scored in somebody else’s numbers: their uptime, their revenue per order, their page load. That turns out to be a very honest way to keep score.'
-    ],
-    readout: [
-      { k: 'Employer', v: 'Big Nerd Ranch' },
-      { k: 'Since', v: 'July 2018' },
-      { k: 'Title', v: 'Solutions Architect' },
-      { k: 'Mode', v: 'Placed inside client engineering teams' }
-    ]
-  },
-  {
-    id: 'apple',
-    index: '02',
     word: 'APPLE',
-    caption: 'transmission 02',
-    kicker: 'Client engagement · 2018–2020',
+    caption: 'chatbot · 2018–2020',
+    kicker: 'Apple, era one · 2018–2020',
     title:
       'Backend lead on Apple’s chatbot, from one million users to fifteen.',
     body: [
@@ -84,14 +66,14 @@ const transmissions: Transmission[] = [
   },
   {
     id: 'chickfila',
-    index: '03',
+    index: '02',
     word: 'CHICK-FIL-A',
-    caption: 'transmission 03',
-    kicker: 'Client engagement · 2020–2022',
+    caption: 'delivery · 2020–2022',
+    kicker: 'Chick-fil-A · 2020–2022',
     title:
       'Project engineering lead for third-party delivery, straight through the pandemic.',
     body: [
-      'Two years leading Chick-fil-A’s third-party delivery integrations. DoorDash, UberEats and Grubhub arrive as three different opinions about what an order is, and have to resolve into one system that a restaurant can actually run on. I held that work through the steepest growth curve any of us had seen: under $1M a day when I started, $5M a day by 2022.',
+      'Two years leading Chick-fil-A’s third-party delivery integrations. DoorDash, UberEats and Grubhub arrive as three different opinions about what an order is, and have to resolve into one system a restaurant can actually run on. I held that work through the steepest growth curve any of us had seen: under $1M a day when I started, $5M a day by 2022.',
       'Specifics, because they are the point. Combo meals on UberEats, worth roughly ten percent more average revenue per order. Checkout with DoorDash inside the Chick-fil-A iOS app, coordinated directly with DoorDash’s engineers. A migration of the project’s infrastructure onto AWS CloudFormation. And a long, unglamorous push on logging, monitoring and observability — because at that volume the question is never “is something broken”, it is “whose”.'
     ],
     readout: [
@@ -105,22 +87,82 @@ const transmissions: Transmission[] = [
     ]
   },
   {
-    id: 'range',
-    index: '04',
-    word: 'RANGE',
-    caption: 'transmission 04',
-    kicker: 'The stack behind the numbers',
-    title: 'What I actually build with.',
+    id: 'apple-solo',
+    index: '03',
+    word: 'SOLO',
+    caption: 'apple · two years, one engineer',
+    kicker: 'Apple, era two · ~2022–2024',
+    title: 'Two years as the only engineer on the product.',
     body: [
-      'JavaScript, TypeScript and Go. Node and Express on the server, Vue and React on the surface. State in MongoDB, DynamoDB or Postgres, chosen from the access pattern rather than from habit. AWS, Docker, Kubernetes and GitHub Actions underneath. Datadog, Splunk and OpsGenie for the part of the job that happens at three in the morning.',
-      'Before the client work there was a freelance rewrite of a WordPress site onto React, Redux, Express and MongoDB — accounts, tour management, a message board — which is where I first owned an entire system end to end. Lately I spend real hours on applied AI, treated exactly like a delivery partner: a component with wide error bars, wrapped in a fallback path.'
+      'Apple asked for me back, and this time the team was one person. For roughly two years I was the sole engineer on Apple’s interface for managing third-party cloud resources — React and TypeScript, owned end to end. Design conversations, architecture, implementation, release, support, the bug someone found on a Sunday. There is no team to hide behind in that arrangement, and no one to absorb a bad decision for you.',
+      'It is the work that turned me from an engineer who ships features into one who owns a product. You learn very quickly which complexity you will still be paying for in a year, and you stop adding it.'
     ],
     readout: [
-      { k: 'Languages', v: 'JavaScript · TypeScript · Go' },
-      { k: 'Server', v: 'Node · Express' },
-      { k: 'Interface', v: 'Vue · React' },
+      { k: 'Client', v: 'Apple' },
+      { k: 'Role', v: 'Sole engineer, end to end' },
+      { k: 'Duration', v: '~2 years' },
+      { k: 'Stack', v: 'React · TypeScript' },
+      { k: 'Product', v: 'Third-party cloud resource management UI' },
+      { k: 'Owned', v: 'Design → build → ship → support' }
+    ]
+  },
+  {
+    id: 'apple-portal',
+    index: '04',
+    word: 'PORTAL',
+    caption: 'apple · current work',
+    kicker: 'Apple, era three · ~2024–present',
+    title:
+      'Now: the front door to Apple’s clouds, becoming a developer portal.',
+    body: [
+      'Current work. I build Apple’s internal cloud website — where engineers inside Apple manage their resources across Apple-internal infrastructure and third-party cloud providers from one place. React and TypeScript again, but the problem has changed shape: this is developer-platform product work, where your users are engineers and every rough edge in your interface is multiplied by everyone who has to use it to do their job.',
+      'It is now expanding into a complete Developer Portal experience. Seven years after I first walked into an Apple engagement as a backend lead, the same relationship has become the place I get to design a platform.'
+    ],
+    readout: [
+      { k: 'Client', v: 'Apple' },
+      { k: 'Since', v: '~2024 – present' },
+      { k: 'Stack', v: 'React · TypeScript' },
+      { k: 'Surface', v: 'Internal cloud management website' },
+      { k: 'Scope', v: 'Apple-internal + third-party cloud providers' },
+      { k: 'Next', v: 'Expanding into a full Developer Portal' }
+    ]
+  },
+  {
+    id: 'firm',
+    index: '05',
+    word: 'SEVEN YEARS',
+    caption: 'one firm · 2018 – present',
+    kicker: 'The through-line · since July 2018',
+    title: 'One firm since 2018. They keep handing me the hard thing.',
+    body: [
+      'Stellar Elements — formerly Big Nerd Ranch, now an Amdocs company — has been my only engineering employer since July 2018. Seven years, one firm, through a rebrand and an acquisition, and an unusual number of first days inside other companies’ codebases.',
+      'The shape of those seven years is the part I would point at. Backend lead at fifteen million users. Engineering lead through a hypergrowth integration crisis. Then sole owner of a product for two years. Now platform and developer-experience work. Nobody plans a career in that order; you get there by being handed something difficult and not needing to be rescued.'
+    ],
+    readout: [
+      { k: 'Employer', v: 'Stellar Elements (formerly Big Nerd Ranch)' },
+      { k: 'Group', v: 'An Amdocs company' },
+      { k: 'Tenure', v: 'July 2018 – present · 7+ years' },
+      { k: 'Clients', v: 'Apple · Chick-fil-A' },
+      { k: 'Arc', v: 'Backend lead → project lead → solo owner → platform' }
+    ]
+  },
+  {
+    id: 'range',
+    index: '06',
+    word: 'RANGE',
+    caption: 'the stack behind it',
+    kicker: 'What I build with',
+    title: 'Product engineer, in the literal sense.',
+    body: [
+      'React, TypeScript and Vue on the surface; Node, Express and Go behind it. State in MongoDB, DynamoDB or Postgres, chosen from the access pattern rather than from habit. AWS, CloudFormation, Docker, Kubernetes and GitHub Actions underneath. Datadog, Splunk and OpsGenie for the part of the job that happens at three in the morning.',
+      'I want the whole line: the interface a person actually touches, the service behind it, and the number that says whether it worked. Lately I spend real hours on applied AI, treated exactly like a delivery partner — a component with wide error bars, wrapped in a fallback path.'
+    ],
+    readout: [
+      { k: 'Interface', v: 'React · TypeScript · Vue' },
+      { k: 'Server', v: 'Node · Express · Go' },
       { k: 'State', v: 'MongoDB · DynamoDB · Postgres' },
-      { k: 'Cloud', v: 'AWS · Docker · Kubernetes · GitHub Actions' },
+      { k: 'Cloud', v: 'AWS · CloudFormation · Docker · Kubernetes' },
+      { k: 'Delivery', v: 'GitHub Actions · CI/CD' },
       { k: 'Signal', v: 'Datadog · Splunk · OpsGenie' }
     ]
   }
@@ -296,15 +338,17 @@ export function CareerExperience() {
             <DecodeText text="signal." duration={0.8} delay={0.25} />
           </h1>
           <p className={styles.heroLede}>
-            I am Devon Bull — a software engineer and Solutions Architect in
-            Raleigh, North Carolina. Economics degree, a startup I helped run, a
-            prototype I taught myself to build, then a bootcamp. Since 2018 I
-            have worked for one consulting firm, <strong>Big Nerd Ranch</strong>
-            , leading backend and platform work inside two of the largest
-            consumer brands in America: <strong>Apple</strong>’s chatbot as it
-            went from one million to fifteen million users, and{' '}
-            <strong>Chick-fil-A</strong>’s third-party delivery integrations as
-            they went from under $1M to $5M a day.
+            I am Devon Bull — a product engineer in Raleigh, North Carolina. An
+            economics degree, a startup I helped run, a prototype I taught
+            myself to build, then a bootcamp. Since 2018 I have been at one
+            firm, <strong>Stellar Elements</strong> (formerly Big Nerd Ranch, an
+            Amdocs company), and most of those seven years have been spent
+            inside <strong>Apple</strong>: backend lead on the chatbot as it
+            grew from one million users to fifteen million, then two years as
+            the only engineer on Apple’s cloud-resource UI, and now the internal
+            cloud site that is becoming Apple’s developer portal. In between I
+            led <strong>Chick-fil-A</strong>’s third-party delivery integrations
+            from under $1M to $5M a day.
           </p>
           <p className={styles.heroNote}>
             Scroll and each section resolves out of the noise. Or don’t — every
@@ -314,8 +358,8 @@ export function CareerExperience() {
 
           <dl className={styles.readoutStrip}>
             {[
-              { k: 'Firm', v: 'Big Nerd Ranch · since 2018' },
-              { k: 'Role', v: 'Solutions Architect' },
+              { k: 'Firm', v: 'Stellar Elements · since 2018' },
+              { k: 'Apple', v: '7 years · three eras' },
               { k: 'Scale', v: '1M → 15M users' },
               { k: 'Throughput', v: '$1M → $5M per day' }
             ].map((item) => (
@@ -387,9 +431,11 @@ export function CareerExperience() {
             <DecodeText text="Currently listening." duration={1} />
           </h2>
           <p className={styles.contactBody}>
-            The work I want has real traffic on it, integrations that fight
-            back, and a team that would rather be correct than comfortable. If
-            that is the room you are standing in, say something.
+            I am looking for <strong>product engineer</strong> work — the whole
+            line, from the interface somebody actually touches to the service
+            and the number behind it. Real traffic on it, integrations that
+            fight back, and a team that would rather be correct than
+            comfortable. If that is the room you are standing in, say something.
           </p>
           <div className={styles.contactLinks}>
             <a href="mailto:devjbull@gmail.com">

--- a/app/career/career-experience.tsx
+++ b/app/career/career-experience.tsx
@@ -1,311 +1,396 @@
 'use client'
 
-import dynamic from 'next/dynamic'
 import Link from 'next/link'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import { DecodeText } from '@/components/signal/decode-text'
+import { SignalFieldMount } from '@/components/signal/signal-field-mount'
+import { createSignalState } from '@/components/signal/signal-types'
+import type { SignalMask } from '@/components/signal/signal-types'
+
 import styles from './career.module.css'
 
-const SpaceScene = dynamic(
-  () =>
-    import('@/components/space/space-scene').then(
-      (module) => module.SpaceScene
-    ),
-  {
-    ssr: false,
-    loading: () => <div className={styles.sceneFallback} aria-hidden="true" />
-  }
-)
+type Transmission = {
+  id: string
+  index: string
+  word: string
+  caption: string
+  kicker: string
+  title: string
+  body: string[]
+  readout: { k: string; v: string }[]
+}
 
-const chapters = {
-  origin: {
-    number: '00',
-    nav: 'Profile',
-    eyebrow: 'Current trajectory',
-    title: 'Devon Bull',
-    meta: 'Senior software engineer · Raleigh, NC',
-    text: 'Former tech entrepreneur turned engineer. I build dependable software, learn new domains quickly, and translate between product ambition and technical reality.'
+const transmissions: Transmission[] = [
+  {
+    id: 'founder',
+    index: '00',
+    word: 'FOUNDER',
+    caption: 'transmission 00',
+    kicker: 'Origin',
+    title: 'Founder first. Engineer second. In that order, on purpose.',
+    body: [
+      'I started a tech company before anyone paid me to write software. I wrote the code, sold the thing, and did the arithmetic that decides whether a company still exists in ninety days. That is the part of engineering no tutorial covers: every technical decision is a bet with a due date attached.',
+      'It left me with a habit I have never dropped. Before I ask what a system costs to build, I ask what it costs to own — on a Tuesday, eighteen months from now, when the person maintaining it has never met me.'
+    ],
+    readout: [
+      { k: 'Role', v: 'Founder' },
+      { k: 'Scope', v: 'Product · sales · code' },
+      { k: 'Residue', v: 'Architecture is a budget' }
+    ]
   },
-  consulting: {
-    number: '01',
-    nav: 'Consulting',
-    eyebrow: 'Primary arc',
-    title: 'Consulting engineer',
-    meta: 'One firm · many problem spaces',
-    text: 'Consulting taught me to arrive curious, earn context quickly, and create momentum inside established teams. The craft is making strong engineering fit the client and the operating environment.'
+  {
+    id: 'consulting',
+    index: '01',
+    word: 'ONE FIRM',
+    caption: 'transmission 01',
+    kicker: 'The arc',
+    title: 'One consulting firm. A long run of other people’s hardest rooms.',
+    body: [
+      'My whole engineering career has been with a single contracting and consulting firm, which means I have had an unusual number of first days. You land inside a codebase you did not write, beside a team that already made its decisions, against a deadline that predates you.',
+      'The work is to be useful in week one and trusted by week four. Read the system before rewriting it. Find the load-bearing assumptions nobody documented. Ship something small and correct that proves you actually understood the thing — then earn the bigger swing.'
+    ],
+    readout: [
+      { k: 'Employer', v: 'One firm, whole career' },
+      { k: 'Mode', v: 'Embedded consultant' },
+      { k: 'Cadence', v: 'New domain · new team · repeat' },
+      { k: 'Core skill', v: 'Acquiring context fast' }
+    ]
   },
-  apple: {
-    number: '02',
-    nav: 'Apple',
-    eyebrow: 'Client system / 01',
-    title: 'Apple',
-    meta: 'Embedded engineering engagement',
-    text: 'Contributed to embedded work where hardware and software had to behave as a single, reliable product. The constraints rewarded precision, disciplined collaboration, and an eye for performance.'
+  {
+    id: 'apple',
+    index: '02',
+    word: 'APPLE',
+    caption: 'transmission 02',
+    kicker: 'Client engagement',
+    title: 'Embedded engineering at Apple, where there is no hotfix on Friday.',
+    body: [
+      'An embedded engagement inside Apple: the seam where hardware and software have to behave as one product. What ships is what lives in somebody’s hand, and the review standard matches that.',
+      'It rewires your defaults. You instrument before you theorise. You respect the timing budget as a hard wall, not a target. You write the failure path first, because the failure path is the product for everyone unlucky enough to find it.'
+    ],
+    readout: [
+      { k: 'Client', v: 'Apple' },
+      { k: 'Domain', v: 'Embedded engineering' },
+      { k: 'Constraint', v: 'Ship-once semantics' },
+      { k: 'Discipline', v: 'Measure, then assert' }
+    ]
   },
-  chickfila: {
-    number: '03',
-    nav: 'Chick-fil-A',
-    eyebrow: 'Client system / 02',
-    title: 'Chick-fil-A',
-    meta: 'Embedded operational systems',
-    text: 'Worked on embedded solutions in an operational environment—connecting physical systems, production software, and the people who rely on both every day.'
+  {
+    id: 'chickfila',
+    index: '03',
+    word: 'CHICK-FIL-A',
+    caption: 'transmission 03',
+    kicker: 'Client engagement',
+    title: 'Embedded systems for a working kitchen, at national scale.',
+    body: [
+      'A second embedded engagement, for Chick-fil-A, in an environment that is nothing like a lab: heat, noise, grease, staff turnover, thousands of locations, and no engineer within a hundred miles of almost any of them.',
+      'Software here is graded on what it does at 12:15 on a Saturday. Recover without being asked. Fail loudly, to the one person who can act. Never require somebody mid-rush to understand your architecture in order to sell a sandwich.'
+    ],
+    readout: [
+      { k: 'Client', v: 'Chick-fil-A' },
+      { k: 'Domain', v: 'Embedded · operations' },
+      { k: 'Constraint', v: 'Unattended, at scale' },
+      { k: 'Discipline', v: 'Design for the worst hour' }
+    ]
   },
-  platforms: {
-    number: '04',
-    nav: 'Range',
-    eyebrow: 'Extended range',
-    title: 'Full-stack platforms',
-    meta: 'Web · cloud · data · delivery',
-    text: 'Beyond embedded systems, I work across TypeScript, React, Node, Go, cloud services, databases, CI/CD, and observability. I like understanding the whole path from interface to infrastructure.'
-  },
-  leadership: {
-    number: '05',
-    nav: 'Leadership',
-    eyebrow: 'How I operate',
-    title: 'Calm, curious leadership',
-    meta: 'Teams · clients · systems',
-    text: 'I do my best work where the problem is ambiguous and the stakes are real: asking useful questions, bringing structure to uncertainty, and helping a team move without unnecessary drama.'
-  },
-  future: {
-    number: '06',
-    nav: 'Next',
-    eyebrow: 'Unresolved signal',
-    title: 'The next hard thing',
-    meta: 'Status · open to contact',
-    text: 'I am most interested in ambitious products, thoughtful teams, and work that expands what people believe software can do. If that sounds familiar, I would love to compare notes.'
+  {
+    id: 'range',
+    index: '04',
+    word: 'RANGE',
+    caption: 'transmission 04',
+    kicker: 'Beyond the device',
+    title: 'Deep on devices. Not confined to them.',
+    body: [
+      'Embedded is where I go deep; it is not the edge of the map. I build product interfaces in TypeScript and React, services in Node and Go, and state in Postgres, DynamoDB or MongoDB — chosen from the access pattern, not from habit.',
+      'Those run on AWS and Google Cloud, usually through Kubernetes, behind a CI/CD path I would be comfortable handing to someone on their second week. Datadog closes the loop. And I spend real hours on applied AI: agents, voice, and tooling treated as components with error bars rather than as magic.'
+    ],
+    readout: [
+      { k: 'Interface', v: 'TypeScript · React' },
+      { k: 'Services', v: 'Node.js · Go' },
+      { k: 'State', v: 'Postgres · DynamoDB · MongoDB' },
+      { k: 'Runtime', v: 'AWS · Google Cloud · Kubernetes' },
+      { k: 'Feedback', v: 'CI/CD · Datadog' },
+      { k: 'Exploring', v: 'Applied AI · agents · voice' }
+    ]
   }
-} as const
+]
 
-type ChapterId = keyof typeof chapters
+const HERO_MASK: SignalMask = {
+  text: 'DEVON BULL',
+  caption: 'senior engineer',
+  oy: 0.27,
+  ox: 0.15
+}
 
-const principles = [
-  {
-    number: '01',
-    title: 'Earn context',
-    text: 'Arrive curious, learn the operating environment, and understand the constraints before prescribing a solution.'
-  },
-  {
-    number: '02',
-    title: 'Connect the system',
-    text: 'Treat product goals, hardware, software, delivery, and the people using the system as one engineering problem.'
-  },
-  {
-    number: '03',
-    title: 'Create calm momentum',
-    text: 'Bring useful questions and enough structure to move an ambiguous problem forward without adding drama.'
-  }
-] as const
+const easeOut = (t: number) => 1 - Math.pow(1 - t, 2.2)
 
 export function CareerExperience() {
-  const [active, setActive] = useState<ChapterId>('origin')
-  const select = useCallback((id: string) => {
-    if (id in chapters) setActive(id as ChapterId)
+  const stateRef = useRef(createSignalState())
+  const rootRef = useRef<HTMLElement | null>(null)
+  const snrRef = useRef<HTMLSpanElement | null>(null)
+  const barRef = useRef<HTMLSpanElement | null>(null)
+  const stationRef = useRef<HTMLSpanElement | null>(null)
+  const [activeId, setActiveId] = useState('hero')
+  const [locked, setLocked] = useState(false)
+  const lockedRef = useRef(false)
+
+  lockedRef.current = locked
+
+  const mask = useMemo<SignalMask>(() => {
+    if (activeId === 'hero') return HERO_MASK
+    if (activeId === 'contact')
+      return { text: 'OPEN', caption: 'signal outbound', ox: 0.16, oy: 0.08 }
+    const t = transmissions.find((item) => item.id === activeId)
+    return t
+      ? { text: t.word, caption: t.caption, ox: 0.17, oy: -0.16 }
+      : HERO_MASK
+  }, [activeId])
+
+  useEffect(() => {
+    const root = rootRef.current
+    if (!root) return
+    const sections = Array.from(
+      root.querySelectorAll<HTMLElement>('[data-signal-section]')
+    )
+    if (!sections.length) return
+
+    let raf = 0
+    let current = ''
+
+    const measure = () => {
+      raf = 0
+      const mid = window.innerHeight * 0.46
+      let best: HTMLElement | null = null
+      let bestDistance = Infinity
+      for (const section of sections) {
+        const rect = section.getBoundingClientRect()
+        const center = rect.top + rect.height / 2
+        const distance = Math.abs(center - mid)
+        if (distance < bestDistance) {
+          bestDistance = distance
+          best = section
+        }
+      }
+      if (!best) return
+      const span = Math.max(window.innerHeight * 0.52, 260)
+      const proximity = easeOut(
+        Math.max(0, Math.min(1, 1 - bestDistance / span))
+      )
+      const reveal = lockedRef.current ? 1 : proximity
+      stateRef.current.reveal = reveal
+      stateRef.current.energy = lockedRef.current ? 0.1 : (1 - proximity) * 0.7
+
+      const id = best.dataset.signalSection ?? ''
+      if (id !== current) {
+        current = id
+        setActiveId(id)
+        if (stationRef.current) {
+          stationRef.current.textContent = (
+            best.dataset.signalLabel ?? id
+          ).toUpperCase()
+        }
+      }
+      if (snrRef.current) snrRef.current.textContent = reveal.toFixed(2)
+      if (barRef.current) {
+        const filled = Math.round(reveal * 10)
+        barRef.current.textContent = `${'\u2588'.repeat(filled)}${'\u2591'.repeat(
+          10 - filled
+        )}`
+      }
+    }
+
+    const onScroll = () => {
+      if (raf) return
+      raf = requestAnimationFrame(measure)
+    }
+
+    measure()
+    window.addEventListener('scroll', onScroll, { passive: true })
+    window.addEventListener('resize', onScroll)
+    return () => {
+      if (raf) cancelAnimationFrame(raf)
+      window.removeEventListener('scroll', onScroll)
+      window.removeEventListener('resize', onScroll)
+    }
   }, [])
-  const chapter = chapters[active]
+
+  const toggleLock = useCallback(() => {
+    setLocked((value) => {
+      const next = !value
+      lockedRef.current = next
+      if (next) {
+        stateRef.current.reveal = 1
+        stateRef.current.energy = 0.1
+      }
+      return next
+    })
+  }, [])
 
   return (
-    <main className={styles.page}>
-      <section className={styles.hero} aria-labelledby="career-title">
-        <SpaceScene mode="career" onNodeSelect={select} />
-        <div className={styles.heroShade} aria-hidden="true" />
+    <main
+      ref={rootRef}
+      data-signal=""
+      data-locked={locked ? 'true' : undefined}
+      className={styles.page}
+    >
+      <div className={styles.fieldLayer}>
+        <SignalFieldMount
+          stateRef={stateRef}
+          mask={mask}
+          gain={activeId === 'hero' ? 1 : 0.86}
+        />
+      </div>
+      <div className={styles.veil} aria-hidden="true" />
+      <div className={styles.grain} aria-hidden="true" />
 
-        <div className={styles.heroHeading}>
-          <p className={styles.eyebrow}>Career constellation · 002</p>
-          <h1 id="career-title">One career. Many systems.</h1>
-          <p>
-            A former tech entrepreneur turned senior software engineer, working
-            from embedded systems to cloud platforms—and translating between
-            ambitious products and the realities that make them dependable.
-          </p>
-          <a className={styles.readLink} href="#career-narrative">
-            Read the complete narrative <span aria-hidden="true">↓</span>
-          </a>
-        </div>
+      <aside className={styles.hud} aria-hidden="true">
+        <span className={styles.hudLabel}>Carrier</span>
+        <span ref={stationRef} className={styles.hudStation}>
+          DEVON BULL
+        </span>
+        <span ref={barRef} className={styles.hudBar}>
+          ░░░░░░░░░░
+        </span>
+        <span className={styles.hudSnr}>
+          lock <span ref={snrRef}>0.00</span>
+        </span>
+      </aside>
 
-        <div className={styles.explorer}>
-          <nav className={styles.chapterNav} aria-label="Career chapters">
-            {Object.entries(chapters).map(([id, item]) => (
-              <button
-                key={id}
-                type="button"
-                className={
-                  active === id
-                    ? styles.chapterButtonActive
-                    : styles.chapterButton
-                }
-                onClick={() => setActive(id as ChapterId)}
-                aria-pressed={active === id}
-              >
-                <span>{item.number}</span>
-                {item.nav}
-              </button>
-            ))}
-          </nav>
-
-          <article
-            className={styles.activeChapter}
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            <p className={styles.panelEyebrow}>{chapter.eyebrow}</p>
-            <div className={styles.chapterTitleRow}>
-              <span>{chapter.number}</span>
-              <h2>{chapter.title}</h2>
-            </div>
-            <p className={styles.chapterMeta}>{chapter.meta}</p>
-            <p className={styles.chapterText}>{chapter.text}</p>
-          </article>
-        </div>
-
-        <p className={styles.visualNote}>
-          Spatial map is optional. Every chapter appears in plain text below.
-        </p>
-      </section>
-
-      <section
-        id="career-narrative"
-        className={styles.narrative}
-        aria-labelledby="narrative-title"
-      >
-        <div className={styles.sectionIntro}>
-          <div>
-            <p className={styles.eyebrow}>Career · in plain text</p>
-            <h2 id="narrative-title">The legible version.</h2>
-          </div>
-          <p>
-            I have worked for one contracting firm across different client and
-            technical contexts. That path built range without losing the
-            through-line: understand the whole system, then make it more
-            dependable.
-          </p>
-        </div>
-
-        <div className={styles.evidenceGrid}>
-          <article
-            className={`${styles.evidenceCard} ${styles.evidenceCardPrimary}`}
-          >
-            <div className={styles.cardTopline}>
-              <span>Foundation</span>
-              <span>Former tech entrepreneur</span>
-            </div>
-            <div>
-              <h3>Product ambition with engineering discipline.</h3>
-              <p>
-                Entrepreneurship shaped how I frame problems and weigh
-                tradeoffs. Engineering became the way I turn that product
-                perspective into reliable systems a team can operate and
-                improve.
-              </p>
-            </div>
-          </article>
-
-          <article className={styles.evidenceCard}>
-            <div className={styles.cardTopline}>
-              <span>Client engagement</span>
-              <span>Embedded</span>
-            </div>
-            <div>
-              <h3>Apple</h3>
-              <p>{chapters.apple.text}</p>
-            </div>
-          </article>
-
-          <article className={styles.evidenceCard}>
-            <div className={styles.cardTopline}>
-              <span>Client engagement</span>
-              <span>Embedded operations</span>
-            </div>
-            <div>
-              <h3>Chick-fil-A</h3>
-              <p>{chapters.chickfila.text}</p>
-            </div>
-          </article>
-        </div>
-      </section>
-
-      <section className={styles.range} aria-labelledby="range-title">
-        <div className={styles.rangeHeading}>
-          <div>
-            <p className={styles.eyebrow}>Engineering range</p>
-            <h2 id="range-title">
-              From device constraints to delivery systems.
-            </h2>
-          </div>
-          <p>
-            Embedded work is a defining part of the story, not the boundary. I
-            also work across application, platform, cloud, data, delivery, and
-            observability concerns.
-          </p>
-        </div>
-        <div
-          className={styles.rangeBands}
-          aria-label="Areas of engineering experience"
+      <div className={styles.content}>
+        <section
+          className={styles.hero}
+          data-signal-section="hero"
+          data-signal-label="Devon Bull"
+          aria-labelledby="career-title"
         >
-          <div>
-            <span>01</span>
-            <strong>Embedded systems</strong>
-            <small>Hardware + software</small>
-          </div>
-          <div>
-            <span>02</span>
-            <strong>Product applications</strong>
-            <small>TypeScript + React + Node</small>
-          </div>
-          <div>
-            <span>03</span>
-            <strong>Services & data</strong>
-            <small>Go + databases</small>
-          </div>
-          <div>
-            <span>04</span>
-            <strong>Platforms</strong>
-            <small>Cloud + CI/CD + observability</small>
-          </div>
-        </div>
-      </section>
+          <p className={styles.eyebrow}>
+            <span>Signal</span>
+            <span aria-hidden="true">·</span>
+            <span>35.7796° N, 78.6382° W</span>
+            <span aria-hidden="true">·</span>
+            <span>Raleigh, North Carolina</span>
+          </p>
+          <h1 id="career-title" className={styles.heroTitle}>
+            <DecodeText text="A résumé is a" duration={0.7} />{' '}
+            <em>
+              <DecodeText text="compressed" duration={1.1} delay={0.12} />
+            </em>{' '}
+            <DecodeText text="signal." duration={0.8} delay={0.25} />
+          </h1>
+          <p className={styles.heroLede}>
+            I am Devon Bull — a senior software engineer in Raleigh, North
+            Carolina. I ran a tech company before I ran a build pipeline. Now I
+            work for one consulting firm and land inside other people’s systems:
+            embedded engineering for <strong>Apple</strong> and{' '}
+            <strong>Chick-fil-A</strong>, plus the full-stack and cloud work
+            that surrounds a device once it starts talking.
+          </p>
+          <p className={styles.heroNote}>
+            Scroll and each section resolves out of the noise. Or don’t — every
+            word below is ordinary text, in order, whether or not the field is
+            running.
+          </p>
 
-      <section className={styles.principles} aria-labelledby="principles-title">
-        <div className={styles.principlesHeading}>
-          <p className={styles.eyebrow}>Operating principles</p>
-          <h2 id="principles-title">
-            How I work when the answer is not obvious.
-          </h2>
-        </div>
-        <div className={styles.principleGrid}>
-          {principles.map((principle) => (
-            <article key={principle.number}>
-              <span>{principle.number}</span>
-              <h3>{principle.title}</h3>
-              <p>{principle.text}</p>
-            </article>
-          ))}
-        </div>
-      </section>
+          <dl className={styles.readoutStrip}>
+            {[
+              { k: 'Firms', v: 'One' },
+              { k: 'Clients', v: 'Apple · Chick-fil-A' },
+              { k: 'Depth', v: 'Firmware → Kubernetes' },
+              { k: 'Base', v: 'Raleigh, NC' }
+            ].map((item) => (
+              <div key={item.k}>
+                <dt>{item.k}</dt>
+                <dd>{item.v}</dd>
+              </div>
+            ))}
+          </dl>
 
-      <section className={styles.nextSignal} aria-labelledby="next-title">
-        <div>
-          <p className={styles.eyebrow}>Next signal</p>
-          <h2 id="next-title">
-            Ambitious products. Thoughtful teams. Hard systems.
+          <div className={styles.heroActions}>
+            <a className={styles.primaryAction} href="#transmission-founder">
+              Begin decoding <span aria-hidden="true">↓</span>
+            </a>
+            <button
+              type="button"
+              className={styles.ghostAction}
+              onClick={toggleLock}
+              aria-pressed={locked}
+            >
+              {locked ? 'Field: locked' : 'Field: free-running'}
+            </button>
+          </div>
+        </section>
+
+        {transmissions.map((item) => (
+          <section
+            key={item.id}
+            id={`transmission-${item.id}`}
+            className={styles.transmission}
+            data-signal-section={item.id}
+            data-signal-label={item.word}
+            aria-labelledby={`heading-${item.id}`}
+          >
+            <div className={styles.rail}>
+              <span className={styles.railIndex} aria-hidden="true">
+                {item.index}
+              </span>
+              <span className={styles.railKicker}>{item.kicker}</span>
+              <dl className={styles.railReadout}>
+                {item.readout.map((row) => (
+                  <div key={row.k}>
+                    <dt>{row.k}</dt>
+                    <dd>{row.v}</dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+            <div className={styles.body}>
+              <h2 id={`heading-${item.id}`} className={styles.bodyTitle}>
+                <DecodeText text={item.title} duration={1.15} />
+              </h2>
+              {item.body.map((paragraph) => (
+                <p key={paragraph.slice(0, 24)}>{paragraph}</p>
+              ))}
+            </div>
+          </section>
+        ))}
+
+        <section
+          id="transmission-contact"
+          className={styles.contact}
+          data-signal-section="contact"
+          data-signal-label="Open"
+          aria-labelledby="contact-heading"
+        >
+          <p className={styles.railKicker}>Signal outbound</p>
+          <h2 id="contact-heading" className={styles.contactTitle}>
+            <DecodeText text="Currently listening." duration={1} />
           </h2>
-        </div>
-        <div className={styles.nextCopy}>
-          <p>{chapters.future.text}</p>
-          <div className={styles.nextLinks}>
-            <Link href="/systems">
-              Explore technical range <span aria-hidden="true">→</span>
-            </Link>
+          <p className={styles.contactBody}>
+            The work I want has hardware, software and operations all holding a
+            vote, and a team that would rather be correct than comfortable. If
+            that is the room you are standing in, say something.
+          </p>
+          <div className={styles.contactLinks}>
             <a
               href="https://www.linkedin.com/in/bulldevon"
               target="_blank"
               rel="noreferrer"
             >
-              Connect on LinkedIn{' '}
-              <span className="sr-only">(opens in a new tab)</span>
-              <span aria-hidden="true">↗</span>
+              LinkedIn <span aria-hidden="true">↗</span>
             </a>
+            <a
+              href="https://github.com/DBULL7"
+              target="_blank"
+              rel="noreferrer"
+            >
+              GitHub <span aria-hidden="true">↗</span>
+            </a>
+            <Link href="/systems">
+              The stack as a field <span aria-hidden="true">→</span>
+            </Link>
           </div>
-        </div>
-      </section>
+        </section>
+      </div>
     </main>
   )
 }

--- a/app/career/career-experience.tsx
+++ b/app/career/career-experience.tsx
@@ -129,8 +129,9 @@ const transmissions: Transmission[] = [
 const HERO_MASK: SignalMask = {
   text: 'DEVON BULL',
   caption: 'senior engineer',
-  oy: 0.27,
-  ox: 0.15
+  oy: 0.33,
+  ox: 0.14,
+  scale: 0.86
 }
 
 const easeOut = (t: number) => 1 - Math.pow(1 - t, 2.2)
@@ -153,7 +154,13 @@ export function CareerExperience() {
       return { text: 'OPEN', caption: 'signal outbound', ox: 0.16, oy: 0.08 }
     const t = transmissions.find((item) => item.id === activeId)
     return t
-      ? { text: t.word, caption: t.caption, ox: 0.17, oy: -0.16 }
+      ? {
+          text: t.word,
+          caption: t.caption,
+          ox: 0.17,
+          oy: -0.27,
+          scale: 0.88
+        }
       : HERO_MASK
   }, [activeId])
 
@@ -248,7 +255,7 @@ export function CareerExperience() {
         <SignalFieldMount
           stateRef={stateRef}
           mask={mask}
-          gain={activeId === 'hero' ? 1 : 0.86}
+          gain={activeId === 'hero' ? 1 : 0.74}
         />
       </div>
       <div className={styles.veil} aria-hidden="true" />

--- a/app/career/career-experience.tsx
+++ b/app/career/career-experience.tsx
@@ -21,40 +21,43 @@ type Transmission = {
   readout: { k: string; v: string }[]
 }
 
+// TODO(devon): the résumé on file ends in 2022. Confirm current title and any
+// client work since the Chick-fil-A engagement, then add a sixth transmission.
 const transmissions: Transmission[] = [
   {
-    id: 'founder',
+    id: 'haller',
     index: '00',
-    word: 'FOUNDER',
+    word: 'HALLER',
     caption: 'transmission 00',
-    kicker: 'Origin',
-    title: 'Founder first. Engineer second. In that order, on purpose.',
+    kicker: 'Origin · 2015',
+    title: 'I shipped the prototype before I could call myself an engineer.',
     body: [
-      'I started a tech company before anyone paid me to write software. I wrote the code, sold the thing, and did the arithmetic that decides whether a company still exists in ninety days. That is the part of engineering no tutorial covers: every technical decision is a bet with a due date attached.',
-      'It left me with a habit I have never dropped. Before I ask what a system costs to build, I ask what it costs to own — on a Tuesday, eighteen months from now, when the person maintaining it has never met me.'
+      'In 2015 I was COO of Haller. I wrote the business plan, got us admitted to a business accelerator, and then — because there was nobody else to hand it to — taught myself Sketch and enough Swift to build the prototype myself. My degree is in economics, not computer science.',
+      'That year left me with the instinct I still lead with: every technical decision is a bet with a due date and a burn rate attached. Turing School followed in 2017, deliberately. I had already proven I could learn a stack under pressure; I wanted to learn one properly.'
     ],
     readout: [
-      { k: 'Role', v: 'Founder' },
-      { k: 'Scope', v: 'Product · sales · code' },
-      { k: 'Residue', v: 'Architecture is a budget' }
+      { k: 'Role', v: 'COO, Haller' },
+      { k: 'Result', v: 'Accelerator admission' },
+      { k: 'Self-taught', v: 'Sketch · Swift prototype' },
+      { k: 'Education', v: 'Turing School 2017 · B.A. Economics, Kansas 2015' }
     ]
   },
   {
-    id: 'consulting',
+    id: 'firm',
     index: '01',
-    word: 'ONE FIRM',
+    word: 'BIG NERD RANCH',
     caption: 'transmission 01',
-    kicker: 'The arc',
-    title: 'One consulting firm. A long run of other people’s hardest rooms.',
+    kicker: 'The arc · since 2018',
+    title: 'One firm since 2018. Big Nerd Ranch, Solutions Architect.',
     body: [
-      'My whole engineering career has been with a single contracting and consulting firm, which means I have had an unusual number of first days. You land inside a codebase you did not write, beside a team that already made its decisions, against a deadline that predates you.',
-      'The work is to be useful in week one and trusted by week four. Read the system before rewriting it. Find the load-bearing assumptions nobody documented. Ship something small and correct that proves you actually understood the thing — then earn the bigger swing.'
+      'My whole engineering career has been with a single consulting firm, which means an unusual number of first days. You land in a codebase you did not write, beside a team that already made its decisions, against a deadline that predates you. Being useful in week one and trusted by week four is the actual skill — the languages are the easy part.',
+      'It also means my work gets scored in somebody else’s numbers: their uptime, their revenue per order, their page load. That turns out to be a very honest way to keep score.'
     ],
     readout: [
-      { k: 'Employer', v: 'One firm, whole career' },
-      { k: 'Mode', v: 'Embedded consultant' },
-      { k: 'Cadence', v: 'New domain · new team · repeat' },
-      { k: 'Core skill', v: 'Acquiring context fast' }
+      { k: 'Employer', v: 'Big Nerd Ranch' },
+      { k: 'Since', v: 'July 2018' },
+      { k: 'Title', v: 'Solutions Architect' },
+      { k: 'Mode', v: 'Placed inside client engineering teams' }
     ]
   },
   {
@@ -62,17 +65,21 @@ const transmissions: Transmission[] = [
     index: '02',
     word: 'APPLE',
     caption: 'transmission 02',
-    kicker: 'Client engagement',
-    title: 'Embedded engineering at Apple, where there is no hotfix on Friday.',
+    kicker: 'Client engagement · 2018–2020',
+    title:
+      'Backend lead on Apple’s chatbot, from one million users to fifteen.',
     body: [
-      'An embedded engagement inside Apple: the seam where hardware and software have to behave as one product. What ships is what lives in somebody’s hand, and the review standard matches that.',
-      'It rewires your defaults. You instrument before you theorise. You respect the timing budget as a hard wall, not a target. You write the failure path first, because the failure path is the product for everyone unlucky enough to find it.'
+      'Two years as backend lead on Apple’s chatbot platform. I implemented the Apple Card integration and helped coordinate its launch, and helped carry the frontend off Angular 1 and onto Vue while the product stayed live in front of everybody.',
+      'The numbers are the argument. Page load from sixty seconds to two. A critical service refactored from ES5 to ES6. Node 5 to Node 12 under production traffic. And 100% uptime while the audience went from one million users to fifteen million. At that volume you stop guessing: instrument first, keep every change reversible, and write the failure path before the feature.'
     ],
     readout: [
       { k: 'Client', v: 'Apple' },
-      { k: 'Domain', v: 'Embedded engineering' },
-      { k: 'Constraint', v: 'Ship-once semantics' },
-      { k: 'Discipline', v: 'Measure, then assert' }
+      { k: 'Role', v: 'Backend lead' },
+      { k: 'Years', v: '2018 – 2020' },
+      { k: 'Shipped', v: 'Apple Card integration' },
+      { k: 'Page load', v: '60s → 2s' },
+      { k: 'Scale', v: '1M → 15M users · 100% uptime' },
+      { k: 'Migrations', v: 'Angular 1 → Vue · Node 5 → 12' }
     ]
   },
   {
@@ -80,17 +87,21 @@ const transmissions: Transmission[] = [
     index: '03',
     word: 'CHICK-FIL-A',
     caption: 'transmission 03',
-    kicker: 'Client engagement',
-    title: 'Embedded systems for a working kitchen, at national scale.',
+    kicker: 'Client engagement · 2020–2022',
+    title:
+      'Project engineering lead for third-party delivery, straight through the pandemic.',
     body: [
-      'A second embedded engagement, for Chick-fil-A, in an environment that is nothing like a lab: heat, noise, grease, staff turnover, thousands of locations, and no engineer within a hundred miles of almost any of them.',
-      'Software here is graded on what it does at 12:15 on a Saturday. Recover without being asked. Fail loudly, to the one person who can act. Never require somebody mid-rush to understand your architecture in order to sell a sandwich.'
+      'Two years leading Chick-fil-A’s third-party delivery integrations. DoorDash, UberEats and Grubhub arrive as three different opinions about what an order is, and have to resolve into one system that a restaurant can actually run on. I held that work through the steepest growth curve any of us had seen: under $1M a day when I started, $5M a day by 2022.',
+      'Specifics, because they are the point. Combo meals on UberEats, worth roughly ten percent more average revenue per order. Checkout with DoorDash inside the Chick-fil-A iOS app, coordinated directly with DoorDash’s engineers. A migration of the project’s infrastructure onto AWS CloudFormation. And a long, unglamorous push on logging, monitoring and observability — because at that volume the question is never “is something broken”, it is “whose”.'
     ],
     readout: [
       { k: 'Client', v: 'Chick-fil-A' },
-      { k: 'Domain', v: 'Embedded · operations' },
-      { k: 'Constraint', v: 'Unattended, at scale' },
-      { k: 'Discipline', v: 'Design for the worst hour' }
+      { k: 'Role', v: 'Project engineering lead' },
+      { k: 'Years', v: '2020 – 2022' },
+      { k: 'Partners', v: 'DoorDash · UberEats · Grubhub' },
+      { k: 'Revenue', v: '<$1M → $5M per day' },
+      { k: 'Lift', v: '~10% higher revenue per order' },
+      { k: 'Infrastructure', v: 'Migrated to AWS CloudFormation' }
     ]
   },
   {
@@ -98,19 +109,19 @@ const transmissions: Transmission[] = [
     index: '04',
     word: 'RANGE',
     caption: 'transmission 04',
-    kicker: 'Beyond the device',
-    title: 'Deep on devices. Not confined to them.',
+    kicker: 'The stack behind the numbers',
+    title: 'What I actually build with.',
     body: [
-      'Embedded is where I go deep; it is not the edge of the map. I build product interfaces in TypeScript and React, services in Node and Go, and state in Postgres, DynamoDB or MongoDB — chosen from the access pattern, not from habit.',
-      'Those run on AWS and Google Cloud, usually through Kubernetes, behind a CI/CD path I would be comfortable handing to someone on their second week. Datadog closes the loop. And I spend real hours on applied AI: agents, voice, and tooling treated as components with error bars rather than as magic.'
+      'JavaScript, TypeScript and Go. Node and Express on the server, Vue and React on the surface. State in MongoDB, DynamoDB or Postgres, chosen from the access pattern rather than from habit. AWS, Docker, Kubernetes and GitHub Actions underneath. Datadog, Splunk and OpsGenie for the part of the job that happens at three in the morning.',
+      'Before the client work there was a freelance rewrite of a WordPress site onto React, Redux, Express and MongoDB — accounts, tour management, a message board — which is where I first owned an entire system end to end. Lately I spend real hours on applied AI, treated exactly like a delivery partner: a component with wide error bars, wrapped in a fallback path.'
     ],
     readout: [
-      { k: 'Interface', v: 'TypeScript · React' },
-      { k: 'Services', v: 'Node.js · Go' },
-      { k: 'State', v: 'Postgres · DynamoDB · MongoDB' },
-      { k: 'Runtime', v: 'AWS · Google Cloud · Kubernetes' },
-      { k: 'Feedback', v: 'CI/CD · Datadog' },
-      { k: 'Exploring', v: 'Applied AI · agents · voice' }
+      { k: 'Languages', v: 'JavaScript · TypeScript · Go' },
+      { k: 'Server', v: 'Node · Express' },
+      { k: 'Interface', v: 'Vue · React' },
+      { k: 'State', v: 'MongoDB · DynamoDB · Postgres' },
+      { k: 'Cloud', v: 'AWS · Docker · Kubernetes · GitHub Actions' },
+      { k: 'Signal', v: 'Datadog · Splunk · OpsGenie' }
     ]
   }
 ]
@@ -278,12 +289,15 @@ export function CareerExperience() {
             <DecodeText text="signal." duration={0.8} delay={0.25} />
           </h1>
           <p className={styles.heroLede}>
-            I am Devon Bull — a senior software engineer in Raleigh, North
-            Carolina. I ran a tech company before I ran a build pipeline. Now I
-            work for one consulting firm and land inside other people’s systems:
-            embedded engineering for <strong>Apple</strong> and{' '}
-            <strong>Chick-fil-A</strong>, plus the full-stack and cloud work
-            that surrounds a device once it starts talking.
+            I am Devon Bull — a software engineer and Solutions Architect in
+            Raleigh, North Carolina. Economics degree, a startup I helped run, a
+            prototype I taught myself to build, then a bootcamp. Since 2018 I
+            have worked for one consulting firm, <strong>Big Nerd Ranch</strong>
+            , leading backend and platform work inside two of the largest
+            consumer brands in America: <strong>Apple</strong>’s chatbot as it
+            went from one million to fifteen million users, and{' '}
+            <strong>Chick-fil-A</strong>’s third-party delivery integrations as
+            they went from under $1M to $5M a day.
           </p>
           <p className={styles.heroNote}>
             Scroll and each section resolves out of the noise. Or don’t — every
@@ -293,10 +307,10 @@ export function CareerExperience() {
 
           <dl className={styles.readoutStrip}>
             {[
-              { k: 'Firms', v: 'One' },
-              { k: 'Clients', v: 'Apple · Chick-fil-A' },
-              { k: 'Depth', v: 'Firmware → Kubernetes' },
-              { k: 'Base', v: 'Raleigh, NC' }
+              { k: 'Firm', v: 'Big Nerd Ranch · since 2018' },
+              { k: 'Role', v: 'Solutions Architect' },
+              { k: 'Scale', v: '1M → 15M users' },
+              { k: 'Throughput', v: '$1M → $5M per day' }
             ].map((item) => (
               <div key={item.k}>
                 <dt>{item.k}</dt>
@@ -306,7 +320,7 @@ export function CareerExperience() {
           </dl>
 
           <div className={styles.heroActions}>
-            <a className={styles.primaryAction} href="#transmission-founder">
+            <a className={styles.primaryAction} href="#transmission-haller">
               Begin decoding <span aria-hidden="true">↓</span>
             </a>
             <button
@@ -366,11 +380,14 @@ export function CareerExperience() {
             <DecodeText text="Currently listening." duration={1} />
           </h2>
           <p className={styles.contactBody}>
-            The work I want has hardware, software and operations all holding a
-            vote, and a team that would rather be correct than comfortable. If
+            The work I want has real traffic on it, integrations that fight
+            back, and a team that would rather be correct than comfortable. If
             that is the room you are standing in, say something.
           </p>
           <div className={styles.contactLinks}>
+            <a href="mailto:devjbull@gmail.com">
+              devjbull@gmail.com <span aria-hidden="true">↗</span>
+            </a>
             <a
               href="https://www.linkedin.com/in/bulldevon"
               target="_blank"

--- a/app/career/career-experience.tsx
+++ b/app/career/career-experience.tsx
@@ -129,7 +129,7 @@ const transmissions: Transmission[] = [
 const HERO_MASK: SignalMask = {
   text: 'DEVON BULL',
   caption: 'senior engineer',
-  oy: 0.33,
+  oy: 0.4,
   ox: 0.14,
   scale: 0.86
 }

--- a/app/career/career.module.css
+++ b/app/career/career.module.css
@@ -33,9 +33,9 @@
     linear-gradient(
       100deg,
       color-mix(in srgb, var(--sig-bg) 92%, transparent) 0%,
-      color-mix(in srgb, var(--sig-bg) 80%, transparent) 30%,
-      color-mix(in srgb, var(--sig-bg) 40%, transparent) 52%,
-      transparent 72%
+      color-mix(in srgb, var(--sig-bg) 86%, transparent) 42%,
+      color-mix(in srgb, var(--sig-bg) 52%, transparent) 66%,
+      transparent 86%
     ),
     linear-gradient(
       0deg,
@@ -269,7 +269,7 @@
   align-items: start;
   padding: clamp(4rem, 11vh, 8rem) 0;
   border-top: 1px solid var(--sig-line-soft);
-  min-height: 78svh;
+  min-height: 66svh;
 }
 
 .rail {
@@ -436,4 +436,20 @@
   .grain {
     opacity: 0.2;
   }
+}
+
+@media (max-width: 860px) {
+  .veil {
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--sig-bg) 74%, transparent) 0%,
+      color-mix(in srgb, var(--sig-bg) 66%, transparent) 55%,
+      color-mix(in srgb, var(--sig-bg) 86%, transparent) 100%
+    );
+  }
+}
+
+html:not(.dark) .grain {
+  opacity: 0.06;
+  mix-blend-mode: multiply;
 }

--- a/app/career/career.module.css
+++ b/app/career/career.module.css
@@ -1,615 +1,439 @@
 .page {
-  color: #dcebe6;
-  background: #03070a;
-}
-
-.hero {
   position: relative;
-  min-height: max(48rem, calc(100svh - 4rem));
-  overflow: hidden;
   isolation: isolate;
+  min-height: 100svh;
+  overflow-x: hidden;
+  color: var(--sig-ink);
+  background: var(--sig-bg);
 }
 
-.heroShade {
-  position: absolute;
+.fieldLayer {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.grain {
+  position: fixed;
+  inset: -20%;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.11;
+  mix-blend-mode: overlay;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='3'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='0.55'/%3E%3C/svg%3E");
+}
+
+.veil {
+  position: fixed;
   inset: 0;
   z-index: 0;
   pointer-events: none;
   background:
     linear-gradient(
-      90deg,
-      rgba(3, 7, 10, 0.96) 0%,
-      rgba(3, 7, 10, 0.52) 39%,
-      transparent 70%
+      100deg,
+      color-mix(in srgb, var(--sig-bg) 92%, transparent) 0%,
+      color-mix(in srgb, var(--sig-bg) 80%, transparent) 30%,
+      color-mix(in srgb, var(--sig-bg) 40%, transparent) 52%,
+      transparent 72%
     ),
-    linear-gradient(0deg, rgba(3, 7, 10, 0.98) 0%, transparent 42%);
+    linear-gradient(
+      0deg,
+      color-mix(in srgb, var(--sig-bg) 88%, transparent) 0%,
+      transparent 30%
+    );
 }
 
-.sceneFallback {
-  position: absolute;
-  inset: 0;
-  background:
-    radial-gradient(
-      circle at 68% 45%,
-      rgba(144, 205, 194, 0.2),
-      transparent 2%
-    ),
-    radial-gradient(
-      circle at 78% 27%,
-      rgba(77, 134, 173, 0.16),
-      transparent 15%
-    ),
-    radial-gradient(
-      circle at 56% 66%,
-      rgba(226, 174, 102, 0.12),
-      transparent 18%
-    ),
-    #03070a;
+.content {
+  position: relative;
+  z-index: 1;
+  width: min(100% - 2.5rem, 78rem);
+  margin: 0 auto;
+  padding-bottom: 8rem;
 }
 
-.heroHeading {
-  position: absolute;
-  top: clamp(3.5rem, 9vh, 7rem);
-  left: clamp(1.25rem, 5vw, 5rem);
+/* ---------------- heads-up readout ---------------- */
+
+.hud {
+  position: fixed;
+  top: 50%;
+  right: 1.6rem;
   z-index: 2;
-  width: min(40rem, calc(100% - 2.5rem));
-}
-
-.eyebrow,
-.panelEyebrow {
-  margin: 0 0 1.1rem;
-  color: #8fc5bd;
-  font:
-    650 0.65rem/1.3 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  letter-spacing: 0.17em;
-  text-transform: uppercase;
-}
-
-.eyebrow::before,
-.panelEyebrow::before {
-  display: inline-block;
-  width: 2.2rem;
-  height: 1px;
-  margin: 0 0.75rem 0.2rem 0;
-  content: '';
-  background: currentColor;
-}
-
-.heroHeading h1 {
-  max-width: 9ch;
-  margin: 0;
-  color: #f3f0e8;
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: clamp(3.6rem, 7vw, 7rem);
-  font-weight: 400;
-  line-height: 0.88;
-  letter-spacing: -0.06em;
-  text-wrap: balance;
-  text-shadow: 0 0 3rem #03070a;
-}
-
-.heroHeading > p:not(.eyebrow) {
-  max-width: 38rem;
-  margin: 1.6rem 0 0;
-  color: rgba(220, 235, 230, 0.68);
-  font-size: clamp(0.95rem, 1.25vw, 1.08rem);
-  line-height: 1.7;
-}
-
-.readLink {
-  display: inline-flex;
-  margin-top: 1.6rem;
-  padding-bottom: 0.35rem;
-  gap: 0.65rem;
-  border-bottom: 1px solid rgba(191, 228, 220, 0.4);
-  color: #bfe4dc;
-  font:
-    650 0.63rem/1 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  letter-spacing: 0.11em;
-  text-transform: uppercase;
-}
-
-.explorer {
-  position: absolute;
-  right: clamp(1.25rem, 4vw, 4rem);
-  bottom: clamp(2rem, 5vh, 4rem);
-  left: clamp(1.25rem, 5vw, 5rem);
-  z-index: 3;
-  display: grid;
-  grid-template-columns: minmax(29rem, 1fr) minmax(23rem, 30rem);
-  gap: clamp(2rem, 7vw, 7rem);
-  align-items: end;
-}
-
-.chapterNav {
-  display: grid;
-  padding-top: 0.6rem;
-  grid-template-columns: repeat(7, minmax(4.5rem, 1fr));
-  border-top: 1px solid rgba(191, 228, 220, 0.18);
-  gap: 0.3rem;
-}
-
-.chapterButton,
-.chapterButtonActive {
-  min-height: 3.5rem;
-  padding: 0.55rem 0.45rem;
-  border: 0;
-  border-radius: 0.15rem;
-  color: rgba(220, 235, 230, 0.48);
-  background: rgba(3, 8, 10, 0.58);
-  font:
-    600 0.56rem/1.25 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  letter-spacing: 0.07em;
-  text-align: left;
-  text-transform: uppercase;
-  cursor: pointer;
-  backdrop-filter: blur(12px);
-  transition:
-    color 160ms ease,
-    background 160ms ease;
-}
-
-.chapterButton span,
-.chapterButtonActive span {
-  display: block;
-  margin-bottom: 0.35rem;
-  color: rgba(191, 228, 220, 0.3);
-}
-
-.chapterButton:hover,
-.chapterButtonActive {
-  color: #edf3ee;
-  background: rgba(42, 104, 98, 0.46);
-}
-
-.activeChapter {
-  min-height: 18rem;
-  padding: 1.5rem;
-  border: 1px solid rgba(191, 228, 220, 0.18);
-  background: rgba(4, 12, 15, 0.8);
-  box-shadow: 0 1.5rem 5rem rgba(0, 0, 0, 0.24);
-  backdrop-filter: blur(18px);
-}
-
-.panelEyebrow {
-  margin-bottom: 1.3rem;
-  font-size: 0.58rem;
-}
-
-.chapterTitleRow {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 1rem;
-  align-items: start;
-}
-
-.chapterTitleRow > span {
-  padding-top: 0.42rem;
-  color: rgba(191, 228, 220, 0.38);
-  font:
-    600 0.6rem/1 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-}
-
-.chapterTitleRow h2 {
-  margin: 0;
-  color: #eef2ed;
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: clamp(1.9rem, 3vw, 2.7rem);
-  font-weight: 400;
-  line-height: 1;
-  letter-spacing: -0.03em;
-}
-
-.chapterMeta {
-  margin: 0.65rem 0 0 2.35rem;
-  color: #8fc5bd;
-  font:
-    600 0.6rem/1.4 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  letter-spacing: 0.09em;
-  text-transform: uppercase;
-}
-
-.chapterText {
-  margin: 1.15rem 0 0 2.35rem;
-  color: rgba(220, 235, 230, 0.66);
-  font-size: 0.9rem;
-  line-height: 1.68;
-}
-
-.visualNote {
-  position: absolute;
-  right: 1rem;
-  bottom: 0.65rem;
-  z-index: 4;
-  margin: 0;
-  color: rgba(220, 235, 230, 0.34);
-  font:
-    500 0.52rem/1.3 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.narrative,
-.range,
-.principles,
-.nextSignal {
-  padding: clamp(5rem, 9vw, 9rem) clamp(1.25rem, 6vw, 6rem);
-}
-
-.narrative {
-  color: #132523;
-  background: #e8eee8;
-}
-
-.narrative .eyebrow,
-.range .eyebrow {
-  color: #39756f;
-}
-
-.sectionIntro,
-.rangeHeading,
-.nextSignal {
-  display: grid;
-  grid-template-columns: minmax(0, 0.9fr) minmax(20rem, 0.65fr);
-  gap: clamp(3rem, 8vw, 8rem);
-  align-items: end;
-}
-
-.sectionIntro,
-.evidenceGrid,
-.rangeHeading,
-.rangeBands,
-.principlesHeading,
-.principleGrid {
-  width: min(100%, 82rem);
-  margin-right: auto;
-  margin-left: auto;
-}
-
-.sectionIntro h2,
-.rangeHeading h2,
-.principlesHeading h2,
-.nextSignal h2 {
-  max-width: 12ch;
-  margin: 0;
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: clamp(2.8rem, 5.4vw, 5.5rem);
-  font-weight: 400;
-  line-height: 0.96;
-  letter-spacing: -0.05em;
-  text-wrap: balance;
-}
-
-.sectionIntro > p,
-.rangeHeading > p,
-.nextCopy > p {
-  margin: 0;
-  color: rgba(19, 37, 35, 0.68);
-  font-size: clamp(1rem, 1.45vw, 1.15rem);
-  line-height: 1.75;
-}
-
-.evidenceGrid {
-  display: grid;
-  margin-top: clamp(3.5rem, 7vw, 6.5rem);
-  grid-template-columns: 1.15fr 1fr 1fr;
-  gap: 1px;
-  background: rgba(25, 58, 54, 0.18);
-}
-
-.evidenceCard {
-  display: flex;
-  min-height: 26rem;
-  padding: 1.5rem;
+  display: none;
   flex-direction: column;
-  justify-content: space-between;
-  background: #edf1eb;
+  gap: 0.35rem;
+  padding: 0.85rem 0.95rem;
+  border: 1px solid var(--sig-line);
+  border-radius: 2px;
+  background: var(--sig-glass);
+  backdrop-filter: blur(10px);
+  transform: translateY(-50%);
+  text-align: right;
+  font:
+    500 0.62rem/1.5 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--sig-ink-3);
 }
 
-.evidenceCardPrimary {
-  color: #e8f0eb;
-  background:
-    radial-gradient(
-      circle at 76% 24%,
-      rgba(107, 185, 174, 0.16),
-      transparent 24%
-    ),
-    #071215;
+.hudLabel {
+  color: var(--sig-ink-3);
 }
 
-.cardTopline {
+.hudStation {
+  color: var(--sig-ink);
+  letter-spacing: 0.18em;
+}
+
+.hudBar {
+  color: var(--sig-signal);
+  letter-spacing: 0.02em;
+  font-size: 0.7rem;
+}
+
+.hudSnr span {
+  color: var(--sig-accent);
+}
+
+@media (min-width: 1180px) {
+  .hud {
+    display: flex;
+  }
+}
+
+/* ---------------- hero ---------------- */
+
+.hero {
   display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-  color: rgba(19, 37, 35, 0.48);
+  flex-direction: column;
+  justify-content: center;
+  min-height: calc(100svh - 4rem);
+  padding: 6rem 0 5rem;
+}
+
+.eyebrow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin: 0 0 2rem;
+  color: var(--sig-ink-3);
   font:
-    600 0.57rem/1.3 ui-monospace,
+    500 0.66rem/1 ui-monospace,
     SFMono-Regular,
     Menlo,
     monospace;
-  letter-spacing: 0.09em;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
 }
 
-.evidenceCardPrimary .cardTopline {
-  color: rgba(220, 235, 230, 0.45);
+.eyebrow span:first-child {
+  color: var(--sig-signal);
 }
 
-.evidenceCard h3 {
+.heroTitle {
   margin: 0;
-  color: inherit;
+  max-width: 16ch;
   font-family: Georgia, 'Times New Roman', serif;
-  font-size: clamp(2rem, 3.2vw, 3.2rem);
+  font-size: clamp(2.9rem, 8.4vw, 7.2rem);
   font-weight: 400;
-  line-height: 1;
-  letter-spacing: -0.04em;
+  line-height: 0.94;
+  letter-spacing: -0.035em;
+  text-wrap: balance;
 }
 
-.evidenceCard p {
+.heroTitle em {
+  font-style: italic;
+  color: var(--sig-signal);
+}
+
+.heroLede {
+  max-width: 36rem;
+  margin: 2.2rem 0 0;
+  color: var(--sig-ink-2);
+  font-size: clamp(1.02rem, 1.5vw, 1.2rem);
+  line-height: 1.62;
+}
+
+.heroLede strong {
+  color: var(--sig-ink);
+  font-weight: 600;
+}
+
+.heroNote {
+  max-width: 34rem;
   margin: 1.1rem 0 0;
-  color: rgba(19, 37, 35, 0.66);
+  padding-left: 0.9rem;
+  border-left: 1px solid var(--sig-line);
+  color: var(--sig-ink-3);
   font-size: 0.9rem;
-  line-height: 1.68;
+  line-height: 1.6;
 }
 
-.evidenceCardPrimary p {
-  color: rgba(220, 235, 230, 0.62);
-}
-
-.range {
-  color: #17302e;
-  background: #dce6df;
-}
-
-.rangeBands {
+.readoutStrip {
   display: grid;
-  margin-top: clamp(3rem, 6vw, 5rem);
-  border-top: 1px solid rgba(25, 58, 54, 0.2);
+  grid-template-columns: repeat(auto-fit, minmax(9.5rem, 1fr));
+  gap: 1px;
+  margin: 3rem 0 0;
+  border: 1px solid var(--sig-line);
+  background: var(--sig-line);
 }
 
-.rangeBands > div {
-  display: grid;
-  min-height: 5.5rem;
-  padding: 1.2rem 0;
-  grid-template-columns: 4rem 1fr minmax(12rem, 0.6fr);
-  gap: 1rem;
-  border-bottom: 1px solid rgba(25, 58, 54, 0.16);
-  align-items: center;
+.readoutStrip > div {
+  padding: 0.9rem 1rem 1rem;
+  background: color-mix(in srgb, var(--sig-bg) 78%, transparent);
+  backdrop-filter: blur(6px);
 }
 
-.rangeBands span,
-.rangeBands small {
-  color: rgba(23, 48, 46, 0.5);
+.readoutStrip dt {
+  margin: 0 0 0.45rem;
+  color: var(--sig-ink-3);
   font:
-    600 0.62rem/1.4 ui-monospace,
+    500 0.6rem/1 ui-monospace,
     SFMono-Regular,
     Menlo,
     monospace;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
 }
 
-.rangeBands strong {
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: clamp(1.4rem, 2.4vw, 2.1rem);
-  font-weight: 400;
+.readoutStrip dd {
+  margin: 0;
+  color: var(--sig-ink);
+  font-size: 0.88rem;
+  line-height: 1.4;
 }
 
-.principles {
-  border-top: 1px solid rgba(191, 228, 220, 0.08);
-  background:
-    radial-gradient(circle at 78% 22%, rgba(42, 99, 94, 0.18), transparent 25%),
-    #050b0e;
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 2.4rem;
 }
 
-.principlesHeading h2 {
-  max-width: 15ch;
-  color: #f0f1eb;
+.primaryAction,
+.ghostAction {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.8rem 1.3rem;
+  border: 1px solid transparent;
+  border-radius: 2px;
+  cursor: pointer;
+  font:
+    600 0.68rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  transition:
+    background 0.25s ease,
+    color 0.25s ease,
+    border-color 0.25s ease;
 }
 
-.principleGrid {
+.primaryAction {
+  color: var(--sig-bg);
+  background: var(--sig-signal);
+}
+
+.primaryAction:hover {
+  background: color-mix(in srgb, var(--sig-signal) 78%, var(--sig-ink));
+}
+
+.ghostAction {
+  color: var(--sig-ink-2);
+  background: transparent;
+  border-color: var(--sig-line);
+}
+
+.ghostAction:hover {
+  color: var(--sig-ink);
+  border-color: var(--sig-signal);
+}
+
+.page[data-locked='true'] .ghostAction {
+  color: var(--sig-accent);
+  border-color: color-mix(in srgb, var(--sig-accent) 55%, transparent);
+}
+
+/* ---------------- transmissions ---------------- */
+
+.transmission {
   display: grid;
-  margin-top: clamp(3.5rem, 7vw, 6rem);
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1px;
-  background: rgba(191, 228, 220, 0.12);
+  grid-template-columns: minmax(0, 15rem) minmax(0, 1fr);
+  gap: clamp(1.5rem, 5vw, 4.5rem);
+  align-items: start;
+  padding: clamp(4rem, 11vh, 8rem) 0;
+  border-top: 1px solid var(--sig-line-soft);
+  min-height: 78svh;
 }
 
-.principleGrid article {
-  min-height: 19rem;
-  padding: 1.5rem;
-  background: rgba(6, 16, 19, 0.96);
+.rail {
+  position: sticky;
+  top: 6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
 }
 
-.principleGrid span {
-  color: rgba(191, 228, 220, 0.38);
+.railIndex {
+  display: block;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: clamp(3.4rem, 7vw, 5.6rem);
+  line-height: 0.8;
+  letter-spacing: -0.04em;
+  color: transparent;
+  -webkit-text-stroke: 1px color-mix(in srgb, var(--sig-ink-3) 62%, transparent);
+}
+
+.railKicker {
+  color: var(--sig-signal);
   font:
     600 0.62rem/1 ui-monospace,
     SFMono-Regular,
     Menlo,
     monospace;
-}
-
-.principleGrid h3 {
-  margin: 5rem 0 0;
-  color: #edf1eb;
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: clamp(1.8rem, 3vw, 2.7rem);
-  font-weight: 400;
-  line-height: 1;
-}
-
-.principleGrid p {
-  margin: 1rem 0 0;
-  color: rgba(220, 235, 230, 0.58);
-  font-size: 0.89rem;
-  line-height: 1.68;
-}
-
-.nextSignal {
-  width: min(100%, 94rem);
-  margin: 0 auto;
-  background: #03070a;
-}
-
-.nextSignal h2 {
-  max-width: 14ch;
-  color: #f1f0e9;
-}
-
-.nextCopy > p {
-  color: rgba(220, 235, 230, 0.6);
-}
-
-.nextLinks {
-  display: flex;
-  margin-top: 1.8rem;
-  flex-wrap: wrap;
-  gap: 1.5rem;
-}
-
-.nextLinks a {
-  display: inline-flex;
-  padding-bottom: 0.35rem;
-  gap: 0.6rem;
-  border-bottom: 1px solid rgba(191, 228, 220, 0.32);
-  color: #bfe4dc;
-  font:
-    650 0.64rem/1 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  letter-spacing: 0.09em;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
 }
 
-@media (max-width: 1000px) {
-  .hero {
-    min-height: 60rem;
-  }
-
-  .heroShade {
-    background: linear-gradient(
-      0deg,
-      rgba(3, 7, 10, 0.99) 0%,
-      rgba(3, 7, 10, 0.42) 67%,
-      rgba(3, 7, 10, 0.64) 100%
-    );
-  }
-
-  .heroHeading {
-    top: 3.5rem;
-  }
-
-  .explorer {
-    grid-template-columns: 1fr;
-    gap: 1rem;
-  }
-
-  .chapterNav {
-    order: 2;
-    overflow-x: auto;
-    scrollbar-width: none;
-  }
-
-  .chapterButton,
-  .chapterButtonActive {
-    min-width: 6.5rem;
-  }
-
-  .activeChapter {
-    width: min(100%, 34rem);
-    min-height: 16rem;
-  }
-
-  .evidenceGrid,
-  .principleGrid {
-    grid-template-columns: 1fr;
-  }
-
-  .evidenceCard {
-    min-height: 21rem;
-  }
-
-  .principleGrid article {
-    min-height: 16rem;
-  }
-
-  .principleGrid h3 {
-    margin-top: 3rem;
-  }
+.railReadout {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+  padding-top: 1.1rem;
+  border-top: 1px solid var(--sig-line);
 }
 
-@media (max-width: 720px) {
-  .hero {
-    min-height: 64rem;
+.railReadout dt {
+  color: var(--sig-ink-3);
+  font:
+    500 0.58rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.railReadout dd {
+  margin: 0.3rem 0 0;
+  color: var(--sig-ink-2);
+  font-size: 0.85rem;
+  line-height: 1.45;
+}
+
+.body {
+  max-width: 40rem;
+}
+
+.bodyTitle {
+  margin: 0 0 1.6rem;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: clamp(1.8rem, 3.6vw, 3rem);
+  font-weight: 400;
+  line-height: 1.08;
+  letter-spacing: -0.025em;
+  text-wrap: balance;
+}
+
+.body p {
+  margin: 0 0 1.15rem;
+  color: var(--sig-ink-2);
+  font-size: clamp(1rem, 1.25vw, 1.09rem);
+  line-height: 1.72;
+}
+
+.body p:last-child {
+  margin-bottom: 0;
+}
+
+/* ---------------- contact ---------------- */
+
+.contact {
+  padding: clamp(4rem, 12vh, 8rem) 0 2rem;
+  border-top: 1px solid var(--sig-line-soft);
+}
+
+.contactTitle {
+  margin: 1rem 0 1.4rem;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: clamp(2.2rem, 5.6vw, 4.2rem);
+  font-weight: 400;
+  line-height: 1;
+  letter-spacing: -0.03em;
+}
+
+.contactBody {
+  max-width: 38rem;
+  margin: 0;
+  color: var(--sig-ink-2);
+  font-size: clamp(1rem, 1.3vw, 1.12rem);
+  line-height: 1.7;
+}
+
+.contactLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 2.4rem;
+}
+
+.contactLinks a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.8rem 1.2rem;
+  border: 1px solid var(--sig-line);
+  border-radius: 2px;
+  color: var(--sig-ink);
+  font:
+    600 0.66rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  transition:
+    border-color 0.25s ease,
+    color 0.25s ease;
+}
+
+.contactLinks a:hover {
+  color: var(--sig-signal);
+  border-color: var(--sig-signal);
+}
+
+/* ---------------- responsive ---------------- */
+
+@media (max-width: 860px) {
+  .transmission {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1.75rem;
+    min-height: 0;
   }
 
-  .heroHeading {
-    top: 2.7rem;
+  .rail {
+    position: static;
+    flex-direction: column;
+    gap: 0.9rem;
   }
 
-  .heroHeading h1 {
-    font-size: clamp(3.35rem, 16vw, 5rem);
+  .railIndex {
+    font-size: 3rem;
   }
 
-  .explorer {
-    right: 1rem;
-    bottom: 2.2rem;
-    left: 1rem;
-  }
-
-  .activeChapter {
-    min-height: 19rem;
-    padding: 1.2rem;
-  }
-
-  .chapterText,
-  .chapterMeta {
-    margin-left: 0;
-  }
-
-  .visualNote {
-    display: none;
-  }
-
-  .sectionIntro,
-  .rangeHeading,
-  .nextSignal {
-    grid-template-columns: 1fr;
-    gap: 2rem;
-  }
-
-  .rangeBands > div {
-    grid-template-columns: 2.5rem 1fr;
-  }
-
-  .rangeBands small {
-    grid-column: 2;
+  .railReadout {
+    grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .chapterButton,
-  .chapterButtonActive {
-    transition: none;
+  .grain {
+    opacity: 0.2;
   }
 }

--- a/app/career/career.module.css
+++ b/app/career/career.module.css
@@ -376,6 +376,11 @@
   line-height: 1.7;
 }
 
+.contactBody strong {
+  color: var(--sig-ink);
+  font-weight: 600;
+}
+
 .contactLinks {
   display: flex;
   flex-wrap: wrap;

--- a/app/career/page.tsx
+++ b/app/career/page.tsx
@@ -4,7 +4,7 @@ import { CareerExperience } from './career-experience'
 export const metadata: Metadata = {
   title: 'Career | Devon Bull',
   description:
-    'Devon Bull’s experience across embedded client work, full-stack platforms, consulting, and engineering leadership.',
+    'Devon Bull — Solutions Architect at Big Nerd Ranch. Backend lead on Apple’s chatbot (1M → 15M users) and engineering lead on Chick-fil-A’s third-party delivery integrations ($1M → $5M a day).',
   alternates: { canonical: '/career' }
 }
 

--- a/app/career/page.tsx
+++ b/app/career/page.tsx
@@ -4,7 +4,7 @@ import { CareerExperience } from './career-experience'
 export const metadata: Metadata = {
   title: 'Career | Devon Bull',
   description:
-    'Devon Bull — Solutions Architect at Big Nerd Ranch. Backend lead on Apple’s chatbot (1M → 15M users) and engineering lead on Chick-fil-A’s third-party delivery integrations ($1M → $5M a day).',
+    'Devon Bull — product engineer in Raleigh, NC. Seven years at one firm (Stellar Elements, formerly Big Nerd Ranch), most of it inside Apple: backend lead on the chatbot at 1M → 15M users, solo owner of a cloud-resource UI, now Apple’s internal cloud site and developer portal. Plus Chick-fil-A delivery integrations at $5M a day.',
   alternates: { canonical: '/career' }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -113,3 +113,39 @@
     scroll-behavior: auto;
   }
 }
+
+/* ---- Signal direction tokens (career + systems) ---------------------- */
+[data-signal] {
+  --sig-bg: #06080e;
+  --sig-bg-2: #0a0e17;
+  --sig-band: #0d1220;
+  --sig-ink: #eef2f8;
+  --sig-ink-2: #9aa7bd;
+  --sig-ink-3: #66748d;
+  --sig-line: rgba(154, 174, 214, 0.18);
+  --sig-line-soft: rgba(154, 174, 214, 0.09);
+  --sig-signal: #64e3d0;
+  --sig-signal-2: #8b86ff;
+  --sig-accent: #f2b45f;
+  --sig-glass: rgba(12, 17, 28, 0.66);
+  --sig-shadow: 0 24px 60px -32px rgba(0, 0, 0, 0.9);
+  color-scheme: dark;
+}
+
+html:not(.dark) [data-signal],
+[data-signal].sig-light {
+  --sig-bg: #f3f0e9;
+  --sig-bg-2: #ebe6dc;
+  --sig-band: #e4ddd0;
+  --sig-ink: #13161c;
+  --sig-ink-2: #4c5361;
+  --sig-ink-3: #767d8b;
+  --sig-line: rgba(19, 22, 28, 0.16);
+  --sig-line-soft: rgba(19, 22, 28, 0.08);
+  --sig-signal: #0d7263;
+  --sig-signal-2: #3a37a4;
+  --sig-accent: #ab4514;
+  --sig-glass: rgba(247, 245, 239, 0.72);
+  --sig-shadow: 0 24px 60px -34px rgba(40, 34, 24, 0.45);
+  color-scheme: light;
+}

--- a/app/systems/page.tsx
+++ b/app/systems/page.tsx
@@ -4,7 +4,7 @@ import { SystemsExperience } from './systems-experience'
 export const metadata: Metadata = {
   title: 'Systems | Devon Bull',
   description:
-    'Explore how Devon Bull connects interfaces, services, data, cloud infrastructure, delivery feedback, and AI tooling.',
+    'Eight capabilities Devon Bull works in — scale, third-party integrations, legacy modernization, performance, data, cloud, observability and applied AI — with the tradeoff behind each one.',
   alternates: { canonical: '/systems' }
 }
 

--- a/app/systems/page.tsx
+++ b/app/systems/page.tsx
@@ -4,7 +4,7 @@ import { SystemsExperience } from './systems-experience'
 export const metadata: Metadata = {
   title: 'Systems | Devon Bull',
   description:
-    'Eight capabilities Devon Bull works in — scale, third-party integrations, legacy modernization, performance, data, cloud, observability and applied AI — with the tradeoff behind each one.',
+    'Nine capabilities Devon Bull works in — product interface, developer platform, scale, third-party integrations, modernization, data, cloud, observability and applied AI — with the tradeoff behind each one.',
   alternates: { canonical: '/systems' }
 }
 

--- a/app/systems/systems-experience.tsx
+++ b/app/systems/systems-experience.tsx
@@ -25,105 +25,119 @@ type Capability = {
 
 const capabilities: Capability[] = [
   {
-    id: 'embedded',
+    id: 'scale',
     index: '01',
-    short: 'EMBEDDED',
-    name: 'Devices & firmware',
-    tools: 'Embedded C/C++ · device software · the hardware boundary',
-    claim: 'On a device, “we’ll patch it” is a hope, not a plan.',
+    short: 'SCALE',
+    name: 'Traffic & scale',
+    tools: 'Node · Express · high-volume consumer platforms',
+    claim: 'At fifteen million users, every interesting failure is in a seam.',
     tradeoff:
-      'I would rather ship a smaller feature set with a proven recovery path than a rich one that needs a human in the room. Across both embedded engagements — Apple and Chick-fil-A — the expensive defects were never clever algorithms. They were state that survived a reboot it had no business surviving.',
+      'Apple’s chatbot grew from one million users to fifteen million while I was backend lead on it, at 100% uptime. None of that was clever. It was refusing to ship anything I could not roll back, instrumenting before theorising, and treating every dependency as a thing that will eventually be down.',
     x: 0.2,
+    y: 0.24
+  },
+  {
+    id: 'integrations',
+    index: '02',
+    short: 'INTEGRATIONS',
+    name: 'Third-party integrations',
+    tools: 'DoorDash · UberEats · Grubhub · Apple Card',
+    claim:
+      'An integration is a contract with someone who will change it without telling you.',
+    tradeoff:
+      'Three delivery platforms arrive with three different opinions about what an order is. The work is one internal model they all translate into, so no partner’s shape leaks into the domain — plus alerting specific enough to name which of them broke at 11:58 on a Friday.',
+    x: 0.47,
+    y: 0.14
+  },
+  {
+    id: 'modernization',
+    index: '03',
+    short: 'MODERNIZATION',
+    name: 'Legacy modernization',
+    tools: 'Angular 1 → Vue · ES5 → ES6 · Node 5 → 12',
+    claim:
+      'You move a live system the way you defuse one: a wire at a time, verified.',
+    tradeoff:
+      'All three of those migrations happened under production traffic, on products people were using that afternoon. Strangle one seam, ship it, measure, repeat. A big-bang rewrite is a schedule risk wearing an engineering plan as a disguise.',
+    x: 0.75,
     y: 0.28
   },
   {
-    id: 'interface',
-    index: '02',
-    short: 'INTERFACE',
-    name: 'Product interface',
-    tools: 'TypeScript · React',
-    claim: 'The component library is not the architecture. The state model is.',
+    id: 'performance',
+    index: '04',
+    short: 'PERFORMANCE',
+    name: 'Performance',
+    tools: 'Profiling · payload · critical path',
+    claim: 'Sixty seconds to two is never one fix. It is thirty, in order.',
     tradeoff:
-      'The first day on a UI goes to enumerating which states are genuinely possible and making the impossible ones unrepresentable. It costs a day. It buys back the fortnight otherwise spent on defects that are really two booleans which should have been one union.',
-    x: 0.46,
-    y: 0.16
-  },
-  {
-    id: 'services',
-    index: '03',
-    short: 'SERVICES',
-    name: 'Application services',
-    tools: 'Node.js · Go',
-    claim:
-      'Go where the concurrency is real. Node where iteration speed is worth more.',
-    tradeoff:
-      'Choosing a language is a staffing decision wearing a technical costume. I have handed elegant Go services to teams who live in TypeScript and watched ownership quietly evaporate. Now I ask who carries the pager before I ask what benchmarks fastest.',
-    x: 0.72,
-    y: 0.3
+      'Performance work is triage. Measure the path a real user actually takes, rank by what the profile says instead of what the room suspects, and stop when the next fix costs more than it returns. The last 200ms is usually somebody’s pet idea.',
+    x: 0.86,
+    y: 0.6
   },
   {
     id: 'state',
-    index: '04',
+    index: '05',
     short: 'STATE',
     name: 'Data & state',
-    tools: 'Postgres · DynamoDB · MongoDB',
+    tools: 'MongoDB · DynamoDB · Postgres',
     claim: 'Pick the database from the access pattern, not from the résumé.',
     tradeoff:
-      'Postgres until something proves it cannot cope. DynamoDB when the access pattern is genuinely known and the scale is genuinely real — it is a superb key-value store and a punishing query engine. The failure mode I look for first is a document store chosen because nobody wanted to write a migration.',
-    x: 0.83,
-    y: 0.62
+      'Postgres until something proves it cannot cope. DynamoDB when the access pattern is genuinely known and the scale is genuinely real — it is a superb key-value store and a punishing query engine. The first thing I look for is a document store chosen because nobody wanted to write a migration.',
+    x: 0.63,
+    y: 0.8
   },
   {
     id: 'runtime',
-    index: '05',
+    index: '06',
     short: 'RUNTIME',
-    name: 'Cloud runtime',
-    tools: 'AWS · Google Cloud · Kubernetes',
-    claim:
-      'Kubernetes is a cost. Take it on when you are buying something specific with it.',
+    name: 'Cloud & delivery',
+    tools: 'AWS · CloudFormation · Docker · Kubernetes · GitHub Actions',
+    claim: 'Infrastructure you cannot recreate from a file is a rumour.',
     tradeoff:
-      'Most teams need a boring deployment target and a rollback they trust more than they need a scheduler. When Kubernetes is the right answer it is right for a reason somebody can say out loud. When it is not, it becomes a second product the team maintains for free, forever.',
-    x: 0.56,
+      'That is why I oversaw the move of the Chick-fil-A delivery project onto AWS CloudFormation. Most teams need a boring deployment target and a rollback they trust more than they need a scheduler; when Kubernetes is the right answer, it is right for a reason somebody can say out loud.',
+    x: 0.33,
     y: 0.78
   },
   {
-    id: 'feedback',
-    index: '06',
-    short: 'FEEDBACK',
-    name: 'Delivery & feedback',
-    tools: 'CI/CD · GitHub Actions · Datadog',
+    id: 'observability',
+    index: '07',
+    short: 'OBSERVABILITY',
+    name: 'Observability & on-call',
+    tools: 'Datadog · Splunk · OpsGenie',
     claim: 'An alert nobody acts on is a lie you tell yourself every night.',
     tradeoff:
-      'Four alarms that always mean something beat forty that mean maybe. Pipelines the same: a paved road a second-week engineer can follow, checks that fail for exactly one legible reason, and enough production signal to answer “is it us?” inside a minute.',
-    x: 0.28,
-    y: 0.72
+      'At $5M a day the question is never “is something broken”, it is “whose”. Four alarms that always mean something beat forty that mean maybe, and enough logging to answer that question inside a minute is worth more than a quarter of features.',
+    x: 0.15,
+    y: 0.55
   },
   {
     id: 'ai',
-    index: '07',
+    index: '08',
     short: 'APPLIED AI',
     name: 'Applied AI',
     tools: 'Agents · voice interfaces · developer tooling',
     claim:
-      'Models are components with terrible error bars. Design the system around that.',
+      'A model is a third-party integration with worse error bars. Treat it like one.',
     tradeoff:
-      'The interesting engineering is never the prompt; it is the containment. What happens when the output is confidently wrong, how a person sees that, and what the model is allowed to touch. I write the fallback path first — the same instinct firmware taught me.',
+      'The interesting engineering is never the prompt, it is the containment: what happens when the output is confidently wrong, how a person sees that, and what the thing is allowed to touch. I write the fallback path first — the habit came from integrations, not from hype.',
     x: 0.5,
     y: 0.47
   }
 ]
 
 const links: [number, number][] = [
-  [0, 2],
+  [0, 1],
+  [0, 6],
   [1, 2],
+  [1, 7],
   [2, 3],
-  [2, 4],
+  [3, 4],
   [4, 5],
-  [5, 1],
-  [6, 2],
-  [6, 1],
-  [6, 4],
-  [0, 5]
+  [5, 6],
+  [6, 0],
+  [7, 0],
+  [7, 4],
+  [5, 3]
 ]
 
 const pushbacks = [
@@ -260,7 +274,7 @@ export function SystemsExperience() {
             <span aria-hidden="true">·</span>
             <span>02 — field map</span>
             <span aria-hidden="true">·</span>
-            <span>Seven attractors</span>
+            <span>Eight attractors</span>
           </p>
           <h1 id="systems-title" className={styles.heroTitle}>
             <DecodeText text="The stack is not a ladder." duration={0.9} />{' '}
@@ -273,17 +287,17 @@ export function SystemsExperience() {
             </em>
           </h1>
           <p className={styles.heroLede}>
-            Seven capabilities I actually reach for, each with the tradeoff I
-            make when I reach for it. Touch one and the field reorganises around
-            it — the more you perturb it, the more structure shows. The words do
-            not move.
+            Eight things I actually reach for, each with the tradeoff I make
+            when I reach for it — drawn from Apple’s chatbot at fifteen million
+            users and Chick-fil-A’s delivery integrations at $5M a day. Touch
+            one and the field reorganises around it. The words do not move.
           </p>
           <dl className={styles.readoutStrip}>
             {[
-              { k: 'Attractors', v: 'Seven' },
-              { k: 'Depth', v: 'Firmware → Kubernetes' },
-              { k: 'Bias', v: 'Boring until proven otherwise' },
-              { k: 'Proof', v: 'Apple · Chick-fil-A' }
+              { k: 'Attractors', v: 'Eight' },
+              { k: 'Proven at', v: '15M users · $5M/day' },
+              { k: 'Firm', v: 'Big Nerd Ranch' },
+              { k: 'Bias', v: 'Boring until proven otherwise' }
             ].map((item) => (
               <div key={item.k}>
                 <dt>{item.k}</dt>
@@ -303,7 +317,9 @@ export function SystemsExperience() {
         >
           <header className={styles.sectionHead}>
             <span className={styles.sectionKicker}>The field</span>
-            <h2 id="field-heading">Seven attractors, and what each one costs</h2>
+            <h2 id="field-heading">
+              Eight attractors, and what each one costs
+            </h2>
             <p>
               Hover a card, or tab to its title and press it to hold that
               attractor open. Every one of these is a position I have had to
@@ -386,9 +402,10 @@ export function SystemsExperience() {
             <DecodeText text="Same engineer. Other frequency." duration={1} />
           </h2>
           <p>
-            The career that produced these opinions — one consulting firm,
-            embedded work for Apple and Chick-fil-A, and a founder’s habit of
-            counting the cost of ownership — is one page over.
+            The career that produced these opinions — Big Nerd Ranch since 2018,
+            backend lead on Apple’s chatbot, engineering lead on Chick-fil-A’s
+            delivery integrations, and a founder’s habit of counting the cost of
+            ownership — is one page over.
           </p>
           <div className={styles.outroLinks}>
             <Link href="/career">

--- a/app/systems/systems-experience.tsx
+++ b/app/systems/systems-experience.tsx
@@ -1,335 +1,416 @@
 'use client'
 
-import dynamic from 'next/dynamic'
 import Link from 'next/link'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import { DecodeText } from '@/components/signal/decode-text'
+import { SignalFieldMount } from '@/components/signal/signal-field-mount'
+import { createSignalState } from '@/components/signal/signal-types'
+import type { SignalMask, SignalNode } from '@/components/signal/signal-types'
+
 import styles from './systems.module.css'
 
-const SpaceScene = dynamic(
-  () =>
-    import('@/components/space/space-scene').then(
-      (module) => module.SpaceScene
-    ),
-  {
-    ssr: false,
-    loading: () => <div className={styles.sceneFallback} aria-hidden="true" />
-  }
-)
-
-const layers = {
-  interface: {
-    number: '01',
-    short: 'Interface',
-    title: 'Product interface',
-    tools: 'TypeScript · React',
-    role: 'Turn complex product behavior into a clear, accessible interaction model.',
-    question: 'Can a person understand and trust what the system is doing?',
-    inputs: 'Product intent · user context',
-    output: 'Usable product surface'
-  },
-  services: {
-    number: '02',
-    short: 'Services',
-    title: 'Application services',
-    tools: 'Node.js · Go',
-    role: 'Shape APIs, integrations, background work, and production services for clarity and change.',
-    question: 'Can the system evolve without making every change risky?',
-    inputs: 'Requests · events · integrations',
-    output: 'Legible system behavior'
-  },
-  data: {
-    number: '03',
-    short: 'Data',
-    title: 'Data model',
-    tools: 'Postgres · DynamoDB · MongoDB',
-    role: 'Choose pragmatic relational, document, or key-value models around the shape of the problem.',
-    question:
-      'Does the model preserve the information the product actually needs?',
-    inputs: 'Domain rules · access patterns',
-    output: 'Durable system state'
-  },
-  runtime: {
-    number: '04',
-    short: 'Runtime',
-    title: 'Cloud runtime',
-    tools: 'AWS · Google Cloud · Kubernetes',
-    role: 'Create infrastructure and operating environments that support safe delivery without hiding production.',
-    question: 'Can the team understand, operate, and recover the system?',
-    inputs: 'Services · configuration · traffic',
-    output: 'Operable production system'
-  },
-  feedback: {
-    number: '05',
-    short: 'Feedback',
-    title: 'Delivery feedback',
-    tools: 'CI/CD · GitHub Actions · Datadog',
-    role: 'Build paved roads, automated checks, and production feedback loops that let teams move with confidence.',
-    question: 'Will the team know quickly when reality diverges from intent?',
-    inputs: 'Code changes · runtime signals',
-    output: 'Safer, faster iteration'
-  },
-  exploration: {
-    number: '06',
-    short: 'AI',
-    title: 'AI exploration',
-    tools: 'Voice · agents · applied tooling',
-    role: 'Explore useful AI interfaces and tools that expand creative leverage while staying grounded in a real workflow.',
-    question: 'Does the new capability make the work meaningfully better?',
-    inputs: 'Model capability · human workflow',
-    output: 'Useful creative leverage'
-  }
-} as const
-
-type LayerId = keyof typeof layers
-
-const paths = {
-  product: {
-    label: 'Ship a product',
-    description:
-      'Trace intent from the interface through services, state, runtime, and production feedback.',
-    sequence: [
-      'interface',
-      'services',
-      'data',
-      'runtime',
-      'feedback'
-    ] as LayerId[]
-  },
-  operate: {
-    label: 'Operate safely',
-    description:
-      'Start with production feedback, then follow the loop back through runtime and service behavior.',
-    sequence: ['feedback', 'runtime', 'services', 'data'] as LayerId[]
-  },
-  explore: {
-    label: 'Explore AI',
-    description:
-      'Connect a new model capability to an interface, a service boundary, useful state, and a feedback loop.',
-    sequence: [
-      'exploration',
-      'interface',
-      'services',
-      'data',
-      'feedback'
-    ] as LayerId[]
-  }
-} as const
-
-type PathId = keyof typeof paths
-
-const sceneNodeToLayer: Record<string, LayerId> = {
-  typescript: 'interface',
-  react: 'interface',
-  node: 'services',
-  go: 'services',
-  data: 'data',
-  cloud: 'runtime',
-  platform: 'feedback',
-  ai: 'exploration'
+type Capability = {
+  id: string
+  index: string
+  short: string
+  name: string
+  tools: string
+  claim: string
+  tradeoff: string
+  /** position in the field, 0..1 */
+  x: number
+  y: number
 }
 
-export function SystemsExperience() {
-  const [activeLayer, setActiveLayer] = useState<LayerId>('interface')
-  const [activePath, setActivePath] = useState<PathId>('product')
-  const layer = layers[activeLayer]
-  const path = paths[activePath]
+const capabilities: Capability[] = [
+  {
+    id: 'embedded',
+    index: '01',
+    short: 'EMBEDDED',
+    name: 'Devices & firmware',
+    tools: 'Embedded C/C++ · device software · the hardware boundary',
+    claim: 'On a device, “we’ll patch it” is a hope, not a plan.',
+    tradeoff:
+      'I would rather ship a smaller feature set with a proven recovery path than a rich one that needs a human in the room. Across both embedded engagements — Apple and Chick-fil-A — the expensive defects were never clever algorithms. They were state that survived a reboot it had no business surviving.',
+    x: 0.2,
+    y: 0.28
+  },
+  {
+    id: 'interface',
+    index: '02',
+    short: 'INTERFACE',
+    name: 'Product interface',
+    tools: 'TypeScript · React',
+    claim: 'The component library is not the architecture. The state model is.',
+    tradeoff:
+      'The first day on a UI goes to enumerating which states are genuinely possible and making the impossible ones unrepresentable. It costs a day. It buys back the fortnight otherwise spent on defects that are really two booleans which should have been one union.',
+    x: 0.46,
+    y: 0.16
+  },
+  {
+    id: 'services',
+    index: '03',
+    short: 'SERVICES',
+    name: 'Application services',
+    tools: 'Node.js · Go',
+    claim:
+      'Go where the concurrency is real. Node where iteration speed is worth more.',
+    tradeoff:
+      'Choosing a language is a staffing decision wearing a technical costume. I have handed elegant Go services to teams who live in TypeScript and watched ownership quietly evaporate. Now I ask who carries the pager before I ask what benchmarks fastest.',
+    x: 0.72,
+    y: 0.3
+  },
+  {
+    id: 'state',
+    index: '04',
+    short: 'STATE',
+    name: 'Data & state',
+    tools: 'Postgres · DynamoDB · MongoDB',
+    claim: 'Pick the database from the access pattern, not from the résumé.',
+    tradeoff:
+      'Postgres until something proves it cannot cope. DynamoDB when the access pattern is genuinely known and the scale is genuinely real — it is a superb key-value store and a punishing query engine. The failure mode I look for first is a document store chosen because nobody wanted to write a migration.',
+    x: 0.83,
+    y: 0.62
+  },
+  {
+    id: 'runtime',
+    index: '05',
+    short: 'RUNTIME',
+    name: 'Cloud runtime',
+    tools: 'AWS · Google Cloud · Kubernetes',
+    claim:
+      'Kubernetes is a cost. Take it on when you are buying something specific with it.',
+    tradeoff:
+      'Most teams need a boring deployment target and a rollback they trust more than they need a scheduler. When Kubernetes is the right answer it is right for a reason somebody can say out loud. When it is not, it becomes a second product the team maintains for free, forever.',
+    x: 0.56,
+    y: 0.78
+  },
+  {
+    id: 'feedback',
+    index: '06',
+    short: 'FEEDBACK',
+    name: 'Delivery & feedback',
+    tools: 'CI/CD · GitHub Actions · Datadog',
+    claim: 'An alert nobody acts on is a lie you tell yourself every night.',
+    tradeoff:
+      'Four alarms that always mean something beat forty that mean maybe. Pipelines the same: a paved road a second-week engineer can follow, checks that fail for exactly one legible reason, and enough production signal to answer “is it us?” inside a minute.',
+    x: 0.28,
+    y: 0.72
+  },
+  {
+    id: 'ai',
+    index: '07',
+    short: 'APPLIED AI',
+    name: 'Applied AI',
+    tools: 'Agents · voice interfaces · developer tooling',
+    claim:
+      'Models are components with terrible error bars. Design the system around that.',
+    tradeoff:
+      'The interesting engineering is never the prompt; it is the containment. What happens when the output is confidently wrong, how a person sees that, and what the model is allowed to touch. I write the fallback path first — the same instinct firmware taught me.',
+    x: 0.5,
+    y: 0.47
+  }
+]
 
-  const selectSceneNode = useCallback((id: string) => {
-    const nextLayer = sceneNodeToLayer[id]
-    if (nextLayer) setActiveLayer(nextLayer)
+const links: [number, number][] = [
+  [0, 2],
+  [1, 2],
+  [2, 3],
+  [2, 4],
+  [4, 5],
+  [5, 1],
+  [6, 2],
+  [6, 1],
+  [6, 4],
+  [0, 5]
+]
+
+const pushbacks = [
+  {
+    quote: '“Let’s just rewrite it.”',
+    answer:
+      'Nine times in ten that sentence means “I have not finished reading it.” Strangle the old system at one seam, ship, repeat. The business keeps running and you learn what the old code actually knew.'
+  },
+  {
+    quote: '“We will add observability later.”',
+    answer:
+      'Later is after the incident. A service that cannot tell you what it just did is a service you will argue about instead of fix, at an hour nobody enjoys.'
+  },
+  {
+    quote: '“The client team would not understand it.”',
+    answer:
+      'A consultant is temporary by design. If the team I leave behind cannot explain their own system without me, I did not finish the job — I just made myself load-bearing.'
+  }
+]
+
+const IDLE_WEIGHT = 0.3
+
+export function SystemsExperience() {
+  const stateRef = useRef(createSignalState())
+  const rootRef = useRef<HTMLElement | null>(null)
+  const [hovered, setHovered] = useState<string | null>(null)
+  const [pinned, setPinned] = useState<string | null>(null)
+  const activeId = hovered ?? pinned
+  const activeRef = useRef<string | null>(null)
+  activeRef.current = activeId
+
+  const mask = useMemo<SignalMask>(() => {
+    const nodes: SignalNode[] = capabilities.map((item) => ({
+      x: item.x,
+      y: item.y,
+      weight: item.id === activeId ? 1 : IDLE_WEIGHT
+    }))
+    const active = capabilities.find((item) => item.id === activeId)
+    return {
+      nodes,
+      links,
+      text: active?.short,
+      caption: active ? active.tools.split(' · ')[0] : undefined,
+      scale: 0.62,
+      oy: 0.3
+    }
+  }, [activeId])
+
+  useEffect(() => {
+    const root = rootRef.current
+    if (!root) return
+
+    let raf = 0
+    const measure = () => {
+      raf = 0
+      const scrolled = Math.min(
+        1,
+        window.scrollY / Math.max(window.innerHeight * 0.9, 1)
+      )
+      const engaged = activeRef.current ? 1 : 0
+      stateRef.current.reveal = Math.max(
+        0.62 + scrolled * 0.22,
+        engaged ? 1 : 0
+      )
+      stateRef.current.energy = engaged ? 0.9 : 0.12
+      stateRef.current.attractors = capabilities.map((item) => ({
+        x: item.x,
+        y: item.y,
+        strength:
+          item.id === activeRef.current ? 0.85 : IDLE_WEIGHT * 0.35 + 0.04,
+        spin: 1
+      }))
+    }
+    const onScroll = () => {
+      if (raf) return
+      raf = requestAnimationFrame(measure)
+    }
+    measure()
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => {
+      if (raf) cancelAnimationFrame(raf)
+      window.removeEventListener('scroll', onScroll)
+    }
   }, [])
 
-  const choosePath = (id: PathId) => {
-    setActivePath(id)
-    setActiveLayer(paths[id].sequence[0])
-  }
+  const applyField = useCallback((id: string | null) => {
+    activeRef.current = id
+    const engaged = Boolean(id)
+    stateRef.current.reveal = engaged ? 1 : 0.7
+    stateRef.current.energy = engaged ? 0.9 : 0.12
+    stateRef.current.attractors = capabilities.map((item) => ({
+      x: item.x,
+      y: item.y,
+      strength: item.id === id ? 0.85 : IDLE_WEIGHT * 0.35 + 0.04,
+      spin: 1
+    }))
+  }, [])
+
+  const perturb = useCallback(
+    (id: string | null) => {
+      setHovered(id)
+      applyField(id ?? pinned)
+    },
+    [applyField, pinned]
+  )
+
+  const togglePin = useCallback(
+    (id: string) => {
+      setPinned((current) => {
+        const next = current === id ? null : id
+        applyField(next)
+        return next
+      })
+    },
+    [applyField]
+  )
 
   return (
-    <main className={styles.page}>
-      <section className={styles.hero} aria-labelledby="systems-title">
-        <SpaceScene mode="systems" onNodeSelect={selectSceneNode} />
-        <div className={styles.heroShade} aria-hidden="true" />
-        <div className={styles.heroHeading}>
-          <p className={styles.eyebrow}>Systems atlas · 003</p>
-          <h1 id="systems-title">Breadth is useful when the parts connect.</h1>
-          <p>
-            My toolkit spans interfaces, services, data, cloud, delivery, and AI
-            exploration. This atlas shows the handoffs between them—not just the
-            names of the tools.
+    <main ref={rootRef} data-signal="" className={styles.page}>
+      <div className={styles.fieldLayer}>
+        <SignalFieldMount
+          stateRef={stateRef}
+          mask={mask}
+          gain={activeId ? 1 : 0.9}
+        />
+      </div>
+      <div className={styles.veil} aria-hidden="true" />
+      <div className={styles.grain} aria-hidden="true" />
+
+      <div className={styles.content}>
+        <section className={styles.hero} aria-labelledby="systems-title">
+          <p className={styles.eyebrow}>
+            <span>Signal</span>
+            <span aria-hidden="true">·</span>
+            <span>02 — field map</span>
+            <span aria-hidden="true">·</span>
+            <span>Seven attractors</span>
           </p>
-        </div>
-
-        <div className={styles.pathExplorer}>
-          <div className={styles.pathHeader}>
-            <div>
-              <span className={styles.pathKicker}>Select an outcome path</span>
-              <div
-                className={styles.pathTabs}
-                role="group"
-                aria-label="Engineering outcome paths"
-              >
-                {Object.entries(paths).map(([id, item]) => (
-                  <button
-                    key={id}
-                    type="button"
-                    className={
-                      activePath === id ? styles.pathTabActive : styles.pathTab
-                    }
-                    onClick={() => choosePath(id as PathId)}
-                    aria-pressed={activePath === id}
-                  >
-                    {item.label}
-                  </button>
-                ))}
+          <h1 id="systems-title" className={styles.heroTitle}>
+            <DecodeText text="The stack is not a ladder." duration={0.9} />{' '}
+            <em>
+              <DecodeText
+                text="It is a field of forces."
+                duration={1.1}
+                delay={0.2}
+              />
+            </em>
+          </h1>
+          <p className={styles.heroLede}>
+            Seven capabilities I actually reach for, each with the tradeoff I
+            make when I reach for it. Touch one and the field reorganises around
+            it — the more you perturb it, the more structure shows. The words do
+            not move.
+          </p>
+          <dl className={styles.readoutStrip}>
+            {[
+              { k: 'Attractors', v: 'Seven' },
+              { k: 'Depth', v: 'Firmware → Kubernetes' },
+              { k: 'Bias', v: 'Boring until proven otherwise' },
+              { k: 'Proof', v: 'Apple · Chick-fil-A' }
+            ].map((item) => (
+              <div key={item.k}>
+                <dt>{item.k}</dt>
+                <dd>{item.v}</dd>
               </div>
-            </div>
-            <p>{path.description}</p>
-          </div>
+            ))}
+          </dl>
+          <a className={styles.primaryAction} href="#field">
+            Perturb the field <span aria-hidden="true">↓</span>
+          </a>
+        </section>
 
-          <div
-            className={styles.signalPath}
-            aria-label={`${path.label} capability sequence`}
-          >
-            {Object.entries(layers).map(([id, item]) => {
-              const layerId = id as LayerId
-              const sequenceIndex = path.sequence.indexOf(layerId)
-              const isInPath = sequenceIndex >= 0
-              const isActive = activeLayer === layerId
+        <section
+          id="field"
+          className={styles.field}
+          aria-labelledby="field-heading"
+        >
+          <header className={styles.sectionHead}>
+            <span className={styles.sectionKicker}>The field</span>
+            <h2 id="field-heading">Seven attractors, and what each one costs</h2>
+            <p>
+              Hover a card, or tab to its title and press it to hold that
+              attractor open. Every one of these is a position I have had to
+              defend on somebody else’s deadline.
+            </p>
+          </header>
 
-              return (
-                <button
-                  key={id}
-                  type="button"
-                  className={`${styles.layerNode} ${isInPath ? styles.layerNodeInPath : ''} ${isActive ? styles.layerNodeActive : ''}`}
-                  onClick={() => setActiveLayer(layerId)}
-                  aria-pressed={isActive}
+          <ul className={styles.cards}>
+            {capabilities.map((item) => (
+              <li key={item.id}>
+                <article
+                  className={styles.card}
+                  data-active={item.id === activeId ? 'true' : undefined}
+                  data-pinned={item.id === pinned ? 'true' : undefined}
+                  aria-labelledby={`cap-${item.id}`}
+                  onMouseEnter={() => perturb(item.id)}
+                  onMouseLeave={() => perturb(null)}
                 >
-                  <span className={styles.layerOrder}>
-                    {isInPath
-                      ? String(sequenceIndex + 1).padStart(2, '0')
-                      : '—'}
-                  </span>
-                  <strong>{item.short}</strong>
-                  <small>{item.tools}</small>
-                </button>
-              )
-            })}
+                  <p className={styles.cardTop}>
+                    <span>{item.index}</span>
+                    <span>{item.short}</span>
+                  </p>
+                  <h3 id={`cap-${item.id}`} className={styles.cardName}>
+                    <button
+                      type="button"
+                      className={styles.cardButton}
+                      aria-pressed={item.id === pinned}
+                      onClick={() => togglePin(item.id)}
+                      onFocus={() => perturb(item.id)}
+                      onBlur={() => perturb(null)}
+                    >
+                      {item.name}
+                      <span className={styles.cardHint}>
+                        {item.id === pinned ? 'held' : 'hold attractor'}
+                      </span>
+                    </button>
+                  </h3>
+                  <p className={styles.cardTools}>{item.tools}</p>
+                  <p className={styles.cardClaim}>{item.claim}</p>
+                  <p className={styles.cardTradeoff}>{item.tradeoff}</p>
+                </article>
+              </li>
+            ))}
+            <li>
+              <div className={styles.legend}>
+                <p className={styles.legendTitle}>Field key</p>
+                <p>
+                  Each card is an attractor in the simulation running behind
+                  this page. Hold one open and the flow reorganises around it,
+                  links brighten, the name burns in. None of the writing depends
+                  on that happening.
+                </p>
+              </div>
+            </li>
+          </ul>
+        </section>
+
+        <section className={styles.pushback} aria-labelledby="pushback-heading">
+          <header className={styles.sectionHead}>
+            <span className={styles.sectionKicker}>Where I push back</span>
+            <h2 id="pushback-heading">
+              Three sentences I have learned to answer slowly
+            </h2>
+          </header>
+          <ol className={styles.pushbackList}>
+            {pushbacks.map((item, i) => (
+              <li key={item.quote}>
+                <span className={styles.pushbackIndex} aria-hidden="true">
+                  {String(i + 1).padStart(2, '0')}
+                </span>
+                <blockquote>{item.quote}</blockquote>
+                <p>{item.answer}</p>
+              </li>
+            ))}
+          </ol>
+        </section>
+
+        <section className={styles.outro} aria-labelledby="outro-heading">
+          <h2 id="outro-heading" className={styles.outroTitle}>
+            <DecodeText text="Same engineer. Other frequency." duration={1} />
+          </h2>
+          <p>
+            The career that produced these opinions — one consulting firm,
+            embedded work for Apple and Chick-fil-A, and a founder’s habit of
+            counting the cost of ownership — is one page over.
+          </p>
+          <div className={styles.outroLinks}>
+            <Link href="/career">
+              Read the career signal <span aria-hidden="true">→</span>
+            </Link>
+            <a
+              href="https://www.linkedin.com/in/bulldevon"
+              target="_blank"
+              rel="noreferrer"
+            >
+              LinkedIn <span aria-hidden="true">↗</span>
+            </a>
+            <a
+              href="https://github.com/DBULL7"
+              target="_blank"
+              rel="noreferrer"
+            >
+              GitHub <span aria-hidden="true">↗</span>
+            </a>
           </div>
-
-          <article
-            className={styles.activeLayer}
-            aria-live="polite"
-            aria-atomic="true"
-          >
-            <div className={styles.activeLayerHeading}>
-              <span>{layer.number}</span>
-              <div>
-                <p>Active capability</p>
-                <h2>{layer.title}</h2>
-              </div>
-              <strong>{layer.tools}</strong>
-            </div>
-            <div className={styles.activeLayerBody}>
-              <p>{layer.role}</p>
-              <dl>
-                <div>
-                  <dt>Input</dt>
-                  <dd>{layer.inputs}</dd>
-                </div>
-                <div>
-                  <dt>Output</dt>
-                  <dd>{layer.output}</dd>
-                </div>
-              </dl>
-              <blockquote>{layer.question}</blockquote>
-            </div>
-          </article>
-        </div>
-      </section>
-
-      <section className={styles.index} aria-labelledby="index-title">
-        <div className={styles.sectionHeading}>
-          <div>
-            <p className={styles.eyebrow}>Capability index · plain text</p>
-            <h2 id="index-title">The whole system, one layer at a time.</h2>
-          </div>
-          <p>
-            No single tool is the point. The value is being able to follow a
-            product decision down through implementation and operations—and
-            bring what production teaches back to the next decision.
-          </p>
-        </div>
-
-        <div className={styles.indexGrid}>
-          {Object.entries(layers).map(([id, item]) => (
-            <article key={id} className={styles.indexCard}>
-              <div className={styles.indexTopline}>
-                <span>{item.number}</span>
-                <span>{item.tools}</span>
-              </div>
-              <div>
-                <h3>{item.title}</h3>
-                <p>{item.role}</p>
-              </div>
-              <dl>
-                <div>
-                  <dt>System question</dt>
-                  <dd>{item.question}</dd>
-                </div>
-              </dl>
-            </article>
-          ))}
-        </div>
-      </section>
-
-      <section className={styles.model} aria-labelledby="model-title">
-        <div className={styles.modelIntro}>
-          <p className={styles.eyebrow}>Systems model</p>
-          <h2 id="model-title">A loop, not a stack.</h2>
-          <p>
-            Product intent moves toward production. Runtime evidence moves back
-            toward the product. Good engineering keeps both directions visible.
-          </p>
-        </div>
-        <ol className={styles.loop}>
-          <li>
-            <span>01</span>
-            <strong>Frame</strong>
-            <small>Understand the product and operating context.</small>
-          </li>
-          <li>
-            <span>02</span>
-            <strong>Connect</strong>
-            <small>Design the boundaries and handoffs between layers.</small>
-          </li>
-          <li>
-            <span>03</span>
-            <strong>Deliver</strong>
-            <small>Make change safe enough to move with confidence.</small>
-          </li>
-          <li>
-            <span>04</span>
-            <strong>Learn</strong>
-            <small>Use production feedback to improve the next decision.</small>
-          </li>
-        </ol>
-      </section>
-
-      <section className={styles.next} aria-labelledby="systems-next-title">
-        <div>
-          <p className={styles.eyebrow}>Context behind the toolkit</p>
-          <h2 id="systems-next-title">See where the range came from.</h2>
-        </div>
-        <div>
-          <p>
-            The career map connects these capabilities to consulting, embedded
-            client work, and an approach to engineering leadership.
-          </p>
-          <Link href="/career">
-            Explore the career map <span aria-hidden="true">→</span>
-          </Link>
-        </div>
-      </section>
+        </section>
+      </div>
     </main>
   )
 }

--- a/app/systems/systems-experience.tsx
+++ b/app/systems/systems-experience.tsx
@@ -25,20 +25,44 @@ type Capability = {
 
 const capabilities: Capability[] = [
   {
-    id: 'scale',
+    id: 'product-ui',
     index: '01',
+    short: 'PRODUCT UI',
+    name: 'Product interface',
+    tools: 'React · TypeScript · design partnership',
+    claim: 'The component library is not the architecture. The state model is.',
+    tradeoff:
+      'I spent two years as the only engineer on an Apple product, which is the fastest way to learn that the first day of a UI belongs to enumerating which states are genuinely possible and making the impossible ones unrepresentable. It costs a day. It buys back the fortnight otherwise spent on defects that are really two booleans which should have been one union.',
+    x: 0.18,
+    y: 0.2
+  },
+  {
+    id: 'platform',
+    index: '02',
+    short: 'DEV PLATFORM',
+    name: 'Developer platform',
+    tools: 'Internal tooling · cloud management · developer portal',
+    claim: 'When your users are engineers, every rough edge gets multiplied.',
+    tradeoff:
+      'I build Apple’s internal cloud website, where engineers manage resources across Apple-internal infrastructure and third-party providers, and it is now growing into a full developer portal. Platform work rewards the unglamorous choice: one obvious path, named the same thing everywhere, that does not require reading the source to trust.',
+    x: 0.45,
+    y: 0.12
+  },
+  {
+    id: 'scale',
+    index: '03',
     short: 'SCALE',
     name: 'Traffic & scale',
     tools: 'Node · Express · high-volume consumer platforms',
     claim: 'At fifteen million users, every interesting failure is in a seam.',
     tradeoff:
       'Apple’s chatbot grew from one million users to fifteen million while I was backend lead on it, at 100% uptime. None of that was clever. It was refusing to ship anything I could not roll back, instrumenting before theorising, and treating every dependency as a thing that will eventually be down.',
-    x: 0.2,
-    y: 0.24
+    x: 0.74,
+    y: 0.2
   },
   {
     id: 'integrations',
-    index: '02',
+    index: '04',
     short: 'INTEGRATIONS',
     name: 'Third-party integrations',
     tools: 'DoorDash · UberEats · Grubhub · Apple Card',
@@ -46,73 +70,61 @@ const capabilities: Capability[] = [
       'An integration is a contract with someone who will change it without telling you.',
     tradeoff:
       'Three delivery platforms arrive with three different opinions about what an order is. The work is one internal model they all translate into, so no partner’s shape leaks into the domain — plus alerting specific enough to name which of them broke at 11:58 on a Friday.',
-    x: 0.47,
-    y: 0.14
+    x: 0.87,
+    y: 0.5
   },
   {
     id: 'modernization',
-    index: '03',
+    index: '05',
     short: 'MODERNIZATION',
     name: 'Legacy modernization',
-    tools: 'Angular 1 → Vue · ES5 → ES6 · Node 5 → 12',
+    tools: 'Angular 1 → Vue · ES5 → ES6 · Node 5 → 12 · 60s → 2s',
     claim:
       'You move a live system the way you defuse one: a wire at a time, verified.',
     tradeoff:
-      'All three of those migrations happened under production traffic, on products people were using that afternoon. Strangle one seam, ship it, measure, repeat. A big-bang rewrite is a schedule risk wearing an engineering plan as a disguise.',
-    x: 0.75,
-    y: 0.28
-  },
-  {
-    id: 'performance',
-    index: '04',
-    short: 'PERFORMANCE',
-    name: 'Performance',
-    tools: 'Profiling · payload · critical path',
-    claim: 'Sixty seconds to two is never one fix. It is thirty, in order.',
-    tradeoff:
-      'Performance work is triage. Measure the path a real user actually takes, rank by what the profile says instead of what the room suspects, and stop when the next fix costs more than it returns. The last 200ms is usually somebody’s pet idea.',
-    x: 0.86,
-    y: 0.6
+      'All of those migrations happened under production traffic, on a product people were using that afternoon, and the page load came down from sixty seconds to two along the way. That is never one fix; it is thirty, ranked by what the profile says instead of what the room suspects. A big-bang rewrite is a schedule risk wearing an engineering plan as a disguise.',
+    x: 0.76,
+    y: 0.78
   },
   {
     id: 'state',
-    index: '05',
+    index: '06',
     short: 'STATE',
     name: 'Data & state',
     tools: 'MongoDB · DynamoDB · Postgres',
     claim: 'Pick the database from the access pattern, not from the résumé.',
     tradeoff:
       'Postgres until something proves it cannot cope. DynamoDB when the access pattern is genuinely known and the scale is genuinely real — it is a superb key-value store and a punishing query engine. The first thing I look for is a document store chosen because nobody wanted to write a migration.',
-    x: 0.63,
-    y: 0.8
+    x: 0.5,
+    y: 0.86
   },
   {
     id: 'runtime',
-    index: '06',
+    index: '07',
     short: 'RUNTIME',
     name: 'Cloud & delivery',
     tools: 'AWS · CloudFormation · Docker · Kubernetes · GitHub Actions',
     claim: 'Infrastructure you cannot recreate from a file is a rumour.',
     tradeoff:
       'That is why I oversaw the move of the Chick-fil-A delivery project onto AWS CloudFormation. Most teams need a boring deployment target and a rollback they trust more than they need a scheduler; when Kubernetes is the right answer, it is right for a reason somebody can say out loud.',
-    x: 0.33,
+    x: 0.22,
     y: 0.78
   },
   {
     id: 'observability',
-    index: '07',
+    index: '08',
     short: 'OBSERVABILITY',
     name: 'Observability & on-call',
     tools: 'Datadog · Splunk · OpsGenie',
     claim: 'An alert nobody acts on is a lie you tell yourself every night.',
     tradeoff:
       'At $5M a day the question is never “is something broken”, it is “whose”. Four alarms that always mean something beat forty that mean maybe, and enough logging to answer that question inside a minute is worth more than a quarter of features.',
-    x: 0.15,
-    y: 0.55
+    x: 0.12,
+    y: 0.5
   },
   {
     id: 'ai',
-    index: '08',
+    index: '09',
     short: 'APPLIED AI',
     name: 'Applied AI',
     tools: 'Agents · voice interfaces · developer tooling',
@@ -121,23 +133,24 @@ const capabilities: Capability[] = [
     tradeoff:
       'The interesting engineering is never the prompt, it is the containment: what happens when the output is confidently wrong, how a person sees that, and what the thing is allowed to touch. I write the fallback path first — the habit came from integrations, not from hype.',
     x: 0.5,
-    y: 0.47
+    y: 0.49
   }
 ]
 
 const links: [number, number][] = [
   [0, 1],
-  [0, 6],
+  [0, 8],
   [1, 2],
-  [1, 7],
+  [1, 8],
   [2, 3],
   [3, 4],
   [4, 5],
   [5, 6],
-  [6, 0],
+  [6, 7],
   [7, 0],
-  [7, 4],
-  [5, 3]
+  [8, 5],
+  [8, 3],
+  [6, 4]
 ]
 
 const pushbacks = [
@@ -274,7 +287,7 @@ export function SystemsExperience() {
             <span aria-hidden="true">·</span>
             <span>02 — field map</span>
             <span aria-hidden="true">·</span>
-            <span>Eight attractors</span>
+            <span>Nine attractors</span>
           </p>
           <h1 id="systems-title" className={styles.heroTitle}>
             <DecodeText text="The stack is not a ladder." duration={0.9} />{' '}
@@ -287,16 +300,16 @@ export function SystemsExperience() {
             </em>
           </h1>
           <p className={styles.heroLede}>
-            Eight things I actually reach for, each with the tradeoff I make
-            when I reach for it — drawn from Apple’s chatbot at fifteen million
-            users and Chick-fil-A’s delivery integrations at $5M a day. Touch
-            one and the field reorganises around it. The words do not move.
+            Nine things I actually reach for, each with the tradeoff I make when
+            I reach for it — drawn from seven years inside Apple and two inside
+            Chick-fil-A’s delivery integrations. Touch one and the field
+            reorganises around it. The words do not move.
           </p>
           <dl className={styles.readoutStrip}>
             {[
-              { k: 'Attractors', v: 'Eight' },
+              { k: 'Attractors', v: 'Nine' },
               { k: 'Proven at', v: '15M users · $5M/day' },
-              { k: 'Firm', v: 'Big Nerd Ranch' },
+              { k: 'Firm', v: 'Stellar Elements · since 2018' },
               { k: 'Bias', v: 'Boring until proven otherwise' }
             ].map((item) => (
               <div key={item.k}>
@@ -317,13 +330,13 @@ export function SystemsExperience() {
         >
           <header className={styles.sectionHead}>
             <span className={styles.sectionKicker}>The field</span>
-            <h2 id="field-heading">
-              Eight attractors, and what each one costs
-            </h2>
+            <h2 id="field-heading">Nine attractors, and what each one costs</h2>
             <p>
-              Hover a card, or tab to its title and press it to hold that
-              attractor open. Every one of these is a position I have had to
-              defend on somebody else’s deadline.
+              Each card is an attractor in the simulation running behind this
+              page. Hover one, or tab to its title and press it to hold the
+              attractor open, and the flow reorganises around it. Every one of
+              these is a position I have had to defend on somebody else’s
+              deadline — none of the writing depends on the field running.
             </p>
           </header>
 
@@ -363,17 +376,6 @@ export function SystemsExperience() {
                 </article>
               </li>
             ))}
-            <li>
-              <div className={styles.legend}>
-                <p className={styles.legendTitle}>Field key</p>
-                <p>
-                  Each card is an attractor in the simulation running behind
-                  this page. Hold one open and the flow reorganises around it,
-                  links brighten, the name burns in. None of the writing depends
-                  on that happening.
-                </p>
-              </div>
-            </li>
           </ul>
         </section>
 
@@ -402,10 +404,10 @@ export function SystemsExperience() {
             <DecodeText text="Same engineer. Other frequency." duration={1} />
           </h2>
           <p>
-            The career that produced these opinions — Big Nerd Ranch since 2018,
-            backend lead on Apple’s chatbot, engineering lead on Chick-fil-A’s
-            delivery integrations, and a founder’s habit of counting the cost of
-            ownership — is one page over.
+            The career that produced these opinions — one firm since 2018, seven
+            years inside Apple across three eras, a hypergrowth delivery
+            integration in the middle of it, and a founder’s habit of counting
+            the cost of ownership — is one page over.
           </p>
           <div className={styles.outroLinks}>
             <Link href="/career">

--- a/app/systems/systems.module.css
+++ b/app/systems/systems.module.css
@@ -492,3 +492,19 @@
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
+
+@media (max-width: 860px) {
+  .veil {
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--sig-bg) 74%, transparent) 0%,
+      color-mix(in srgb, var(--sig-bg) 66%, transparent) 55%,
+      color-mix(in srgb, var(--sig-bg) 86%, transparent) 100%
+    );
+  }
+}
+
+html:not(.dark) .grain {
+  opacity: 0.06;
+  mix-blend-mode: multiply;
+}

--- a/app/systems/systems.module.css
+++ b/app/systems/systems.module.css
@@ -341,39 +341,6 @@
   line-height: 1.66;
 }
 
-.legend {
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  gap: 0.8rem;
-  padding: 1.6rem 1.5rem 1.8rem;
-  background: color-mix(in srgb, var(--sig-band) 55%, transparent);
-  backdrop-filter: blur(8px);
-}
-
-.legendTitle {
-  margin: 0;
-  color: var(--sig-signal);
-  font:
-    600 0.6rem/1 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  letter-spacing: 0.22em;
-  text-transform: uppercase;
-}
-
-.legend p {
-  margin: 0;
-  color: var(--sig-ink-3);
-  font:
-    500 0.74rem/1.7 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  letter-spacing: 0.02em;
-}
-
 /* ---------------- pushback ---------------- */
 
 .pushback {

--- a/app/systems/systems.module.css
+++ b/app/systems/systems.module.css
@@ -1,735 +1,506 @@
 .page {
-  color: #dcebe6;
-  background: #03070a;
-}
-
-.hero {
   position: relative;
-  min-height: max(60rem, calc(100svh - 4rem));
-  overflow: hidden;
   isolation: isolate;
+  min-height: 100svh;
+  overflow-x: hidden;
+  color: var(--sig-ink);
+  background: var(--sig-bg);
 }
 
-.heroShade {
-  position: absolute;
+.fieldLayer {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.veil {
+  position: fixed;
   inset: 0;
   z-index: 0;
   pointer-events: none;
   background:
-    linear-gradient(90deg, rgba(3, 7, 10, 0.94) 0%, transparent 52%),
     linear-gradient(
-      0deg,
-      rgba(3, 7, 10, 0.99) 0%,
-      rgba(3, 7, 10, 0.2) 55%,
-      rgba(3, 7, 10, 0.35) 100%
+      100deg,
+      color-mix(in srgb, var(--sig-bg) 88%, transparent) 0%,
+      color-mix(in srgb, var(--sig-bg) 64%, transparent) 32%,
+      transparent 62%
+    ),
+    linear-gradient(
+      180deg,
+      transparent 0%,
+      color-mix(in srgb, var(--sig-bg) 30%, transparent) 46%,
+      color-mix(in srgb, var(--sig-bg) 82%, transparent) 78%,
+      var(--sig-bg) 100%
+    ),
+    radial-gradient(
+      120% 60% at 50% 0%,
+      color-mix(in srgb, var(--sig-bg) 55%, transparent) 0%,
+      transparent 70%
     );
 }
 
-.sceneFallback {
-  position: absolute;
-  inset: 0;
-  background:
-    radial-gradient(
-      circle at 70% 30%,
-      rgba(106, 203, 191, 0.2),
-      transparent 4%
-    ),
-    radial-gradient(
-      ellipse at 70% 30%,
-      transparent 18%,
-      rgba(94, 167, 163, 0.12) 18.5%,
-      transparent 19%
-    ),
-    radial-gradient(
-      circle at 22% 76%,
-      rgba(77, 134, 173, 0.15),
-      transparent 26%
-    ),
-    #03070a;
+.grain {
+  position: fixed;
+  inset: -20%;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.11;
+  mix-blend-mode: overlay;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='3'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)' opacity='0.55'/%3E%3C/svg%3E");
+}
+
+.content {
+  position: relative;
+  z-index: 1;
+  width: min(100% - 2.5rem, 78rem);
+  margin: 0 auto;
+  padding-bottom: 8rem;
+}
+
+/* ---------------- hero ---------------- */
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: calc(100svh - 4rem);
+  padding: 6rem 0 5rem;
 }
 
 .eyebrow {
-  margin: 0 0 1.15rem;
-  color: #8fc5bd;
-  font:
-    650 0.65rem/1.3 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  letter-spacing: 0.17em;
-  text-transform: uppercase;
-}
-
-.eyebrow::before {
-  display: inline-block;
-  width: 2.2rem;
-  height: 1px;
-  margin: 0 0.75rem 0.2rem 0;
-  content: '';
-  background: currentColor;
-}
-
-.heroHeading {
-  position: absolute;
-  top: clamp(3rem, 7vh, 6rem);
-  left: clamp(1.25rem, 5vw, 5rem);
-  z-index: 2;
-  width: min(45rem, calc(100% - 2.5rem));
-}
-
-.heroHeading h1 {
-  max-width: 13ch;
-  margin: 0;
-  color: #f3f0e8;
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: clamp(3.5rem, 6.8vw, 6.8rem);
-  font-weight: 400;
-  line-height: 0.89;
-  letter-spacing: -0.06em;
-  text-wrap: balance;
-  text-shadow: 0 0 3rem #03070a;
-}
-
-.heroHeading > p:not(.eyebrow) {
-  max-width: 40rem;
-  margin: 1.6rem 0 0;
-  color: rgba(220, 235, 230, 0.66);
-  font-size: clamp(0.95rem, 1.25vw, 1.08rem);
-  line-height: 1.7;
-}
-
-.pathExplorer {
-  position: absolute;
-  right: clamp(1.25rem, 4vw, 4rem);
-  bottom: clamp(2rem, 5vh, 4rem);
-  left: clamp(1.25rem, 5vw, 5rem);
-  z-index: 3;
-  padding: 1.2rem;
-  border: 1px solid rgba(191, 228, 220, 0.16);
-  background: rgba(3, 10, 13, 0.79);
-  box-shadow: 0 1.5rem 5rem rgba(0, 0, 0, 0.28);
-  backdrop-filter: blur(18px);
-}
-
-.pathHeader {
-  display: grid;
-  padding: 0.25rem 0.2rem 1rem;
-  grid-template-columns: 1fr minmax(18rem, 0.5fr);
-  gap: 2rem;
-  border-bottom: 1px solid rgba(191, 228, 220, 0.12);
-  align-items: end;
-}
-
-.pathKicker {
-  display: block;
-  margin-bottom: 0.7rem;
-  color: rgba(220, 235, 230, 0.4);
-  font:
-    600 0.54rem/1 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  letter-spacing: 0.11em;
-  text-transform: uppercase;
-}
-
-.pathTabs {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.45rem;
-}
-
-.pathTab,
-.pathTabActive {
-  min-height: 2.35rem;
-  padding: 0 0.8rem;
-  border: 1px solid rgba(191, 228, 220, 0.14);
-  border-radius: 0.15rem;
-  color: rgba(220, 235, 230, 0.52);
-  background: rgba(7, 20, 23, 0.64);
+  gap: 0.6rem;
+  margin: 0 0 2rem;
+  color: var(--sig-ink-3);
   font:
-    650 0.57rem/1 ui-monospace,
+    500 0.66rem/1 ui-monospace,
     SFMono-Regular,
     Menlo,
     monospace;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
-  cursor: pointer;
-  transition:
-    color 160ms ease,
-    border-color 160ms ease,
-    background 160ms ease;
 }
 
-.pathTab:hover,
-.pathTabActive {
-  border-color: rgba(191, 228, 220, 0.54);
-  color: #eef3ee;
-  background: rgba(44, 105, 100, 0.42);
+.eyebrow span:first-child {
+  color: var(--sig-signal);
 }
 
-.pathHeader > p {
+.heroTitle {
   margin: 0;
-  color: rgba(220, 235, 230, 0.54);
-  font-size: 0.78rem;
-  line-height: 1.6;
-}
-
-.signalPath {
-  position: relative;
-  display: grid;
-  padding: 1rem 0;
-  grid-template-columns: repeat(6, 1fr);
-  gap: 0.45rem;
-}
-
-.signalPath::before {
-  position: absolute;
-  top: 50%;
-  right: 4%;
-  left: 4%;
-  height: 1px;
-  content: '';
-  background: linear-gradient(
-    90deg,
-    transparent,
-    rgba(191, 228, 220, 0.25),
-    transparent
-  );
-}
-
-.layerNode {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  min-height: 7.4rem;
-  padding: 0.75rem;
-  border: 1px solid rgba(191, 228, 220, 0.1);
-  flex-direction: column;
-  align-items: flex-start;
-  color: rgba(220, 235, 230, 0.3);
-  background: rgba(4, 12, 15, 0.9);
-  text-align: left;
-  cursor: pointer;
-  transition:
-    color 160ms ease,
-    border-color 160ms ease,
-    background 160ms ease,
-    transform 160ms ease;
-}
-
-.layerNodeInPath {
-  border-color: rgba(142, 200, 190, 0.3);
-  color: rgba(220, 235, 230, 0.72);
-  background: rgba(11, 31, 33, 0.94);
-}
-
-.layerNode:hover,
-.layerNodeActive {
-  border-color: rgba(191, 228, 220, 0.72);
-  color: #f0f3ee;
-  background: rgba(34, 84, 80, 0.84);
-  transform: translateY(-2px);
-}
-
-.layerOrder {
-  color: rgba(191, 228, 220, 0.38);
-  font:
-    600 0.54rem/1 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-}
-
-.layerNode strong {
-  margin-top: auto;
+  max-width: 15ch;
   font-family: Georgia, 'Times New Roman', serif;
-  font-size: 1.25rem;
+  font-size: clamp(2.7rem, 7.6vw, 6.4rem);
   font-weight: 400;
+  line-height: 0.96;
+  letter-spacing: -0.035em;
+  text-wrap: balance;
 }
 
-.layerNode small {
-  margin-top: 0.4rem;
-  color: currentColor;
+.heroTitle em {
+  font-style: italic;
+  color: var(--sig-signal);
+}
+
+.heroLede {
+  max-width: 34rem;
+  margin: 2.2rem 0 0;
+  color: var(--sig-ink-2);
+  font-size: clamp(1.02rem, 1.5vw, 1.18rem);
+  line-height: 1.62;
+}
+
+.readoutStrip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(9.5rem, 1fr));
+  gap: 1px;
+  margin: 3rem 0 0;
+  border: 1px solid var(--sig-line);
+  background: var(--sig-line);
+}
+
+.readoutStrip > div {
+  padding: 0.9rem 1rem 1rem;
+  background: color-mix(in srgb, var(--sig-bg) 78%, transparent);
+  backdrop-filter: blur(6px);
+}
+
+.readoutStrip dt {
+  margin: 0 0 0.45rem;
+  color: var(--sig-ink-3);
   font:
-    500 0.5rem/1.35 ui-monospace,
+    500 0.6rem/1 ui-monospace,
     SFMono-Regular,
     Menlo,
     monospace;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
 }
 
-.activeLayer {
-  border-top: 1px solid rgba(191, 228, 220, 0.12);
+.readoutStrip dd {
+  margin: 0;
+  color: var(--sig-ink);
+  font-size: 0.88rem;
+  line-height: 1.4;
 }
 
-.activeLayerHeading {
-  display: grid;
-  padding: 1rem 0.2rem;
-  grid-template-columns: 2.5rem 1fr auto;
-  gap: 1rem;
+.primaryAction {
+  display: inline-flex;
+  align-self: flex-start;
   align-items: center;
+  gap: 0.55rem;
+  margin-top: 2.4rem;
+  padding: 0.8rem 1.3rem;
+  border-radius: 2px;
+  color: var(--sig-bg);
+  background: var(--sig-signal);
+  font:
+    600 0.68rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  transition: background 0.25s ease;
 }
 
-.activeLayerHeading > span {
-  color: rgba(191, 228, 220, 0.4);
+.primaryAction:hover {
+  background: color-mix(in srgb, var(--sig-signal) 78%, var(--sig-ink));
+}
+
+/* ---------------- section heads ---------------- */
+
+.sectionHead {
+  max-width: 44rem;
+  margin: 0 0 3rem;
+}
+
+.sectionKicker {
+  display: block;
+  margin-bottom: 1rem;
+  color: var(--sig-signal);
+  font:
+    600 0.62rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+
+.sectionHead h2 {
+  margin: 0;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: clamp(1.75rem, 3.4vw, 2.85rem);
+  font-weight: 400;
+  line-height: 1.08;
+  letter-spacing: -0.025em;
+  text-wrap: balance;
+}
+
+.sectionHead p {
+  margin: 1.1rem 0 0;
+  color: var(--sig-ink-2);
+  font-size: 1.02rem;
+  line-height: 1.65;
+}
+
+/* ---------------- capability field ---------------- */
+
+.field {
+  padding: clamp(4rem, 10vh, 7rem) 0;
+  border-top: 1px solid var(--sig-line-soft);
+  scroll-margin-top: 5rem;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  border: 1px solid var(--sig-line);
+  background: var(--sig-line);
+}
+
+.cards > li {
+  display: flex;
+}
+
+.card {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.65rem;
+  padding: 1.6rem 1.5rem 1.8rem;
+  background: color-mix(in srgb, var(--sig-bg) 76%, transparent);
+  backdrop-filter: blur(8px);
+  transition:
+    background 0.35s ease,
+    box-shadow 0.35s ease;
+}
+
+.card[data-active='true'] {
+  background: color-mix(in srgb, var(--sig-band) 90%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--sig-signal) 45%, transparent);
+}
+
+.cardTop {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin: 0;
+  color: var(--sig-ink-3);
+  font:
+    500 0.6rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.card[data-active='true'] .cardTop span:last-child {
+  color: var(--sig-signal);
+}
+
+.cardName {
+  margin: 0.35rem 0 0;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: 1.55rem;
+  font-weight: 400;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+}
+
+.cardButton {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  background: none;
+  cursor: pointer;
+}
+
+.cardHint {
+  color: var(--sig-ink-3);
+  font:
+    500 0.55rem/1 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+}
+
+.card[data-active='true'] .cardHint,
+.cardButton:focus-visible .cardHint {
+  opacity: 1;
+}
+
+.card[data-pinned='true'] .cardHint {
+  color: var(--sig-accent);
+  opacity: 1;
+}
+
+.cardTools {
+  margin: 0;
+  color: var(--sig-ink-3);
+  font:
+    500 0.68rem/1.5 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    monospace;
+  letter-spacing: 0.06em;
+}
+
+.cardClaim {
+  margin: 0.5rem 0 0;
+  color: var(--sig-ink);
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: 1.12rem;
+  font-style: italic;
+  line-height: 1.4;
+  text-wrap: pretty;
+}
+
+.cardTradeoff {
+  margin: 0;
+  color: var(--sig-ink-2);
+  font-size: 0.94rem;
+  line-height: 1.66;
+}
+
+.legend {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 0.8rem;
+  padding: 1.6rem 1.5rem 1.8rem;
+  background: color-mix(in srgb, var(--sig-band) 55%, transparent);
+  backdrop-filter: blur(8px);
+}
+
+.legendTitle {
+  margin: 0;
+  color: var(--sig-signal);
   font:
     600 0.6rem/1 ui-monospace,
     SFMono-Regular,
     Menlo,
     monospace;
-}
-
-.activeLayerHeading p {
-  margin: 0 0 0.25rem;
-  color: #8fc5bd;
-  font:
-    600 0.52rem/1 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
 }
 
-.activeLayerHeading h2 {
+.legend p {
   margin: 0;
-  color: #eef2ed;
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: clamp(1.7rem, 2.8vw, 2.5rem);
-  font-weight: 400;
-  line-height: 1;
-}
-
-.activeLayerHeading strong {
-  color: #9dccca;
+  color: var(--sig-ink-3);
   font:
-    600 0.57rem/1.4 ui-monospace,
+    500 0.74rem/1.7 ui-monospace,
     SFMono-Regular,
     Menlo,
     monospace;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
+  letter-spacing: 0.02em;
 }
 
-.activeLayerBody {
+/* ---------------- pushback ---------------- */
+
+.pushback {
+  padding: clamp(4rem, 10vh, 7rem) 0 0;
+  border-top: 1px solid var(--sig-line-soft);
+}
+
+.pushbackList {
   display: grid;
-  padding: 0.9rem 0.2rem 0.2rem;
-  grid-template-columns: 1fr 0.78fr 0.8fr;
-  gap: clamp(1.5rem, 4vw, 4rem);
-  border-top: 1px solid rgba(191, 228, 220, 0.09);
-  align-items: start;
-}
-
-.activeLayerBody > p,
-.activeLayerBody blockquote {
+  grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
+  gap: clamp(1.75rem, 4vw, 3rem);
   margin: 0;
-  color: rgba(220, 235, 230, 0.62);
-  font-size: 0.78rem;
-  line-height: 1.6;
-}
-
-.activeLayerBody dl {
-  margin: 0;
-}
-
-.activeLayerBody dl > div {
-  display: grid;
-  margin-bottom: 0.5rem;
-  grid-template-columns: 3.5rem 1fr;
-  gap: 0.6rem;
-}
-
-.activeLayerBody dt {
-  color: rgba(220, 235, 230, 0.34);
-  font:
-    600 0.5rem/1.5 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  letter-spacing: 0.09em;
-  text-transform: uppercase;
-}
-
-.activeLayerBody dd {
-  margin: 0;
-  color: rgba(220, 235, 230, 0.66);
-  font-size: 0.7rem;
-  line-height: 1.5;
-}
-
-.activeLayerBody blockquote {
-  padding-left: 1rem;
-  border-left: 1px solid #8fc5bd;
-  color: #c8ddd7;
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: 0.95rem;
-  font-style: italic;
-}
-
-.index,
-.model,
-.next {
-  padding: clamp(5rem, 9vw, 9rem) clamp(1.25rem, 6vw, 6rem);
-}
-
-.index {
-  color: #142826;
-  background: #e8eee8;
-}
-
-.index .eyebrow {
-  color: #39756f;
-}
-
-.sectionHeading,
-.next {
-  display: grid;
-  grid-template-columns: minmax(0, 0.9fr) minmax(20rem, 0.65fr);
-  gap: clamp(3rem, 8vw, 8rem);
-  align-items: end;
-}
-
-.sectionHeading,
-.indexGrid,
-.modelIntro,
-.loop {
-  width: min(100%, 82rem);
-  margin-right: auto;
-  margin-left: auto;
-}
-
-.sectionHeading h2,
-.modelIntro h2,
-.next h2 {
-  max-width: 13ch;
-  margin: 0;
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: clamp(2.8rem, 5.4vw, 5.5rem);
-  font-weight: 400;
-  line-height: 0.96;
-  letter-spacing: -0.05em;
-  text-wrap: balance;
-}
-
-.sectionHeading > p,
-.modelIntro > p:last-child,
-.next > div:last-child > p {
-  margin: 0;
-  color: rgba(20, 40, 38, 0.66);
-  font-size: clamp(1rem, 1.45vw, 1.15rem);
-  line-height: 1.75;
-}
-
-.indexGrid {
-  display: grid;
-  margin-top: clamp(3.5rem, 7vw, 6.5rem);
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1px;
-  background: rgba(25, 58, 54, 0.18);
-}
-
-.indexCard {
-  display: flex;
-  min-height: 24rem;
-  padding: 1.4rem;
-  flex-direction: column;
-  justify-content: space-between;
-  background: #edf1eb;
-}
-
-.indexTopline {
-  display: flex;
-  justify-content: space-between;
-  gap: 1rem;
-  color: rgba(20, 40, 38, 0.48);
-  font:
-    600 0.55rem/1.35 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  letter-spacing: 0.07em;
-  text-transform: uppercase;
-}
-
-.indexTopline span:last-child {
-  text-align: right;
-}
-
-.indexCard h3 {
-  margin: 0;
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: clamp(2rem, 3vw, 3rem);
-  font-weight: 400;
-  line-height: 1;
-  letter-spacing: -0.04em;
-}
-
-.indexCard p {
-  margin: 1rem 0 0;
-  color: rgba(20, 40, 38, 0.64);
-  font-size: 0.88rem;
-  line-height: 1.65;
-}
-
-.indexCard dl,
-.indexCard dd {
-  margin: 0;
-}
-
-.indexCard dl {
-  padding-top: 1rem;
-  border-top: 1px solid rgba(20, 40, 38, 0.12);
-}
-
-.indexCard dt {
-  margin-bottom: 0.45rem;
-  color: #39756f;
-  font:
-    600 0.54rem/1 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    monospace;
-  letter-spacing: 0.09em;
-  text-transform: uppercase;
-}
-
-.indexCard dd {
-  color: rgba(20, 40, 38, 0.6);
-  font-family: Georgia, 'Times New Roman', serif;
-  font-size: 0.92rem;
-  font-style: italic;
-  line-height: 1.5;
-}
-
-.model {
-  border-top: 1px solid rgba(191, 228, 220, 0.08);
-  background:
-    radial-gradient(
-      circle at 76% 30%,
-      rgba(53, 118, 112, 0.2),
-      transparent 28%
-    ),
-    #050b0e;
-}
-
-.modelIntro {
-  display: grid;
-  grid-template-columns: 0.8fr 1fr 0.75fr;
-  gap: clamp(2rem, 6vw, 6rem);
-  align-items: end;
-}
-
-.modelIntro .eyebrow {
-  align-self: start;
-}
-
-.modelIntro h2 {
-  max-width: 9ch;
-  color: #f1f0e9;
-}
-
-.modelIntro > p:last-child {
-  color: rgba(220, 235, 230, 0.58);
-}
-
-.loop {
-  display: grid;
-  margin-top: clamp(3.5rem, 7vw, 6rem);
   padding: 0;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 1px;
-  background: rgba(191, 228, 220, 0.12);
   list-style: none;
 }
 
-.loop li {
+.pushbackList > li {
   display: flex;
-  min-height: 16rem;
-  padding: 1.3rem;
   flex-direction: column;
-  background: rgba(6, 16, 19, 0.96);
+  gap: 0.85rem;
+  padding-top: 1.2rem;
+  border-top: 1px solid var(--sig-line);
 }
 
-.loop span {
-  color: rgba(191, 228, 220, 0.36);
+.pushbackIndex {
+  color: var(--sig-ink-3);
   font:
-    600 0.58rem/1 ui-monospace,
+    500 0.6rem/1 ui-monospace,
     SFMono-Regular,
     Menlo,
     monospace;
+  letter-spacing: 0.2em;
 }
 
-.loop strong {
-  margin-top: auto;
-  color: #edf1eb;
+.pushbackList blockquote {
+  margin: 0;
+  color: var(--sig-accent);
   font-family: Georgia, 'Times New Roman', serif;
-  font-size: clamp(1.8rem, 3vw, 2.7rem);
+  font-size: 1.3rem;
+  line-height: 1.25;
+  letter-spacing: -0.015em;
+}
+
+.pushbackList p {
+  margin: 0;
+  color: var(--sig-ink-2);
+  font-size: 0.96rem;
+  line-height: 1.68;
+}
+
+/* ---------------- outro ---------------- */
+
+.outro {
+  margin-top: clamp(4rem, 10vh, 7rem);
+  padding: clamp(3rem, 8vh, 5rem) 0 0;
+  border-top: 1px solid var(--sig-line-soft);
+}
+
+.outroTitle {
+  margin: 0 0 1.3rem;
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: clamp(2rem, 5vw, 3.6rem);
   font-weight: 400;
+  line-height: 1;
+  letter-spacing: -0.03em;
 }
 
-.loop small {
-  margin-top: 0.7rem;
-  color: rgba(220, 235, 230, 0.55);
-  font-size: 0.78rem;
-  line-height: 1.55;
+.outro > p {
+  max-width: 36rem;
+  margin: 0;
+  color: var(--sig-ink-2);
+  font-size: clamp(1rem, 1.3vw, 1.1rem);
+  line-height: 1.7;
 }
 
-.next {
-  width: min(100%, 94rem);
-  margin: 0 auto;
+.outroLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  margin-top: 2.4rem;
 }
 
-.next h2 {
-  max-width: 11ch;
-  color: #f1f0e9;
-}
-
-.next > div:last-child > p {
-  color: rgba(220, 235, 230, 0.58);
-}
-
-.next a {
+.outroLinks a {
   display: inline-flex;
-  margin-top: 1.6rem;
-  padding-bottom: 0.35rem;
-  gap: 0.65rem;
-  border-bottom: 1px solid rgba(191, 228, 220, 0.34);
-  color: #bfe4dc;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.8rem 1.2rem;
+  border: 1px solid var(--sig-line);
+  border-radius: 2px;
+  color: var(--sig-ink);
   font:
-    650 0.63rem/1 ui-monospace,
+    600 0.66rem/1 ui-monospace,
     SFMono-Regular,
     Menlo,
     monospace;
-  letter-spacing: 0.09em;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
+  transition:
+    border-color 0.25s ease,
+    color 0.25s ease;
 }
 
-@media (max-width: 1000px) {
-  .hero {
-    min-height: 77rem;
-  }
+.outroLinks a:hover {
+  color: var(--sig-signal);
+  border-color: var(--sig-signal);
+}
 
-  .heroShade {
-    background: linear-gradient(
-      0deg,
-      rgba(3, 7, 10, 0.99) 0%,
-      rgba(3, 7, 10, 0.5) 73%,
-      rgba(3, 7, 10, 0.58) 100%
-    );
-  }
-
-  .pathExplorer {
-    right: 1.25rem;
-    left: 1.25rem;
-  }
-
-  .pathHeader,
-  .activeLayerBody {
-    grid-template-columns: 1fr;
-    gap: 1rem;
-  }
-
-  .signalPath {
-    grid-template-columns: repeat(3, 1fr);
-  }
-
-  .activeLayerBody blockquote {
-    display: none;
-  }
-
-  .indexGrid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  .modelIntro {
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .modelIntro .eyebrow {
-    grid-column: 1 / -1;
-  }
-
-  .loop {
-    grid-template-columns: repeat(2, 1fr);
+@media (min-width: 46rem) {
+  .cards {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-@media (max-width: 700px) {
-  .hero {
-    min-height: 92rem;
+@media (min-width: 68rem) {
+  .cards {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
-  .heroHeading {
-    top: 2.8rem;
+  .cards > li:first-child {
+    grid-column: span 2;
   }
 
-  .heroHeading h1 {
-    font-size: clamp(3.25rem, 15.5vw, 5rem);
+  .cards > li:first-child .cardClaim {
+    font-size: 1.35rem;
+    max-width: 26ch;
   }
 
-  .pathExplorer {
-    right: 1rem;
-    bottom: 2rem;
-    left: 1rem;
-    padding: 0.8rem;
-  }
-
-  .pathTabs {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .pathTab,
-  .pathTabActive {
-    width: 100%;
-  }
-
-  .signalPath {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  .layerNode {
-    min-height: 6.6rem;
-  }
-
-  .activeLayerHeading {
-    grid-template-columns: 2rem 1fr;
-  }
-
-  .activeLayerHeading strong {
-    grid-column: 2;
-  }
-
-  .sectionHeading,
-  .next,
-  .modelIntro {
-    grid-template-columns: 1fr;
-    gap: 2rem;
-  }
-
-  .modelIntro .eyebrow {
-    grid-column: auto;
-  }
-
-  .indexGrid,
-  .loop {
-    grid-template-columns: 1fr;
-  }
-
-  .indexCard {
-    min-height: 20rem;
-  }
-
-  .loop li {
-    min-height: 13rem;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .pathTab,
-  .pathTabActive,
-  .layerNode {
-    transition: none;
+  .cards > li:first-child .cardTradeoff {
+    max-width: 52ch;
   }
 }

--- a/app/systems/systems.module.css
+++ b/app/systems/systems.module.css
@@ -244,7 +244,8 @@
 
 .card[data-active='true'] {
   background: color-mix(in srgb, var(--sig-band) 90%, transparent);
-  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--sig-signal) 45%, transparent);
+  box-shadow: inset 0 0 0 1px
+    color-mix(in srgb, var(--sig-signal) 45%, transparent);
 }
 
 .cardTop {
@@ -489,18 +490,5 @@
 @media (min-width: 68rem) {
   .cards {
     grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-
-  .cards > li:first-child {
-    grid-column: span 2;
-  }
-
-  .cards > li:first-child .cardClaim {
-    font-size: 1.35rem;
-    max-width: 26ch;
-  }
-
-  .cards > li:first-child .cardTradeoff {
-    max-width: 52ch;
   }
 }

--- a/components/signal/decode-text.module.css
+++ b/components/signal/decode-text.module.css
@@ -1,0 +1,25 @@
+.root {
+  display: inline-block;
+  position: relative;
+}
+
+.visual {
+  font-variant-ligatures: none;
+  font-kerning: none;
+}
+
+.root[data-resolving='true'] .visual {
+  color: color-mix(in srgb, currentColor 62%, var(--sig-signal) 38%);
+}
+
+.sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}

--- a/components/signal/decode-text.tsx
+++ b/components/signal/decode-text.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import { createElement, useEffect, useRef, useState } from 'react'
+import type { ElementType } from 'react'
+
+import styles from './decode-text.module.css'
+
+const GLYPHS = 'ABCDEFGHJKLMNPQRSTUVWXYZ0123456789#*+=-_/\\|<>[]{}~^%$&'
+
+type Props = {
+  text: string
+  as?: ElementType
+  className?: string
+  /** seconds before the resolve starts once the element is in view */
+  delay?: number
+  /** seconds from first glyph to full lock */
+  duration?: number
+  /** replay every time the element re-enters the viewport */
+  replay?: boolean
+  id?: string
+}
+
+/**
+ * Renders `text` and, on entering the viewport, resolves it out of glyph noise.
+ * The real string is always present in the accessibility tree and in the SSR
+ * markup — the scramble is a purely visual layer that is skipped entirely for
+ * `prefers-reduced-motion`.
+ */
+export function DecodeText({
+  text,
+  as = 'span',
+  className,
+  delay = 0,
+  duration = 0.9,
+  replay = false,
+  id
+}: Props) {
+  const hostRef = useRef<HTMLElement | null>(null)
+  const [display, setDisplay] = useState(text)
+  const [started, setStarted] = useState(false)
+
+  useEffect(() => {
+    const host = hostRef.current
+    if (!host) return
+    if (
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    ) {
+      setDisplay(text)
+      return
+    }
+
+    let raf = 0
+    let cancelled = false
+    const chars = Array.from(text)
+    const seeds = chars.map((_, i) => {
+      const wave = i / Math.max(chars.length - 1, 1)
+      return delay + wave * duration * 0.55 + Math.random() * duration * 0.45
+    })
+
+    const run = () => {
+      const begin = performance.now()
+      setStarted(true)
+      let lastChurn = 0
+      let frame = ''
+      const tick = (now: number) => {
+        if (cancelled) return
+        const t = (now - begin) / 1000
+        const churn = now - lastChurn > 34
+        if (churn) lastChurn = now
+        let done = true
+        if (churn) {
+          frame = chars
+            .map((char, i) => {
+              if (char === ' ' || char === '\u00a0') return char
+              if (t >= seeds[i]) return char
+              done = false
+              return GLYPHS[(Math.random() * GLYPHS.length) | 0]
+            })
+            .join('')
+          setDisplay(frame)
+        } else {
+          done = chars.every((char, i) => char === ' ' || t >= seeds[i])
+        }
+        if (!done) {
+          raf = requestAnimationFrame(tick)
+        } else {
+          setDisplay(text)
+        }
+      }
+      raf = requestAnimationFrame(tick)
+    }
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            run()
+            if (!replay) io.disconnect()
+          }
+        }
+      },
+      { threshold: 0.25 }
+    )
+    io.observe(host)
+
+    return () => {
+      cancelled = true
+      cancelAnimationFrame(raf)
+      io.disconnect()
+    }
+  }, [text, delay, duration, replay])
+
+  return createElement(
+    as,
+    {
+      ref: hostRef,
+      className: `${styles.root} ${className ?? ''}`,
+      id,
+      'data-resolving': started && display !== text ? 'true' : undefined
+    },
+    createElement('span', { 'aria-hidden': 'true', className: styles.visual }, display),
+    createElement('span', { className: styles.sr }, text)
+  )
+}

--- a/components/signal/decode-text.tsx
+++ b/components/signal/decode-text.tsx
@@ -119,7 +119,11 @@ export function DecodeText({
       id,
       'data-resolving': started && display !== text ? 'true' : undefined
     },
-    createElement('span', { 'aria-hidden': 'true', className: styles.visual }, display),
+    createElement(
+      'span',
+      { 'aria-hidden': 'true', className: styles.visual },
+      display
+    ),
     createElement('span', { className: styles.sr }, text)
   )
 }

--- a/components/signal/signal-field-mount.tsx
+++ b/components/signal/signal-field-mount.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+import type { MutableRefObject } from 'react'
+
+import type { SignalMask, SignalState } from './signal-types'
+import styles from './signal-field.module.css'
+
+const SignalField = dynamic(() => import('./signal-field'), {
+  ssr: false,
+  loading: () => <div className={styles.host} aria-hidden="true" />
+})
+
+export function SignalFieldMount(props: {
+  stateRef: MutableRefObject<SignalState>
+  mask: SignalMask
+  className?: string
+  gain?: number
+}) {
+  return <SignalField {...props} />
+}

--- a/components/signal/signal-field.module.css
+++ b/components/signal/signal-field.module.css
@@ -1,0 +1,27 @@
+.host {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  background:
+    radial-gradient(
+      120% 80% at 50% 8%,
+      color-mix(in srgb, var(--sig-signal) 12%, transparent) 0%,
+      transparent 62%
+    ),
+    radial-gradient(
+      90% 70% at 82% 92%,
+      color-mix(in srgb, var(--sig-signal-2) 12%, transparent) 0%,
+      transparent 60%
+    );
+}
+
+.host[data-ready='true'] {
+  background: none;
+}
+
+.canvas {
+  display: block;
+  width: 100% !important;
+  height: 100% !important;
+}

--- a/components/signal/signal-field.tsx
+++ b/components/signal/signal-field.tsx
@@ -313,13 +313,13 @@ const PALETTE: Record<'dark' | 'light', Palette> = {
     coreLo: 0.42
   },
   light: {
-    a: rgb('#0a7f6c'),
-    b: rgb('#3a32ab'),
-    core: rgb('#101c26'),
-    opacity: 0.52,
-    gamma: 1.3,
-    vignette: 0.22,
-    coreLo: 0.66
+    a: rgb('#0d7a68'),
+    b: rgb('#a2481c'),
+    core: rgb('#1b2a33'),
+    opacity: 0.72,
+    gamma: 1.55,
+    vignette: 0.16,
+    coreLo: 0.6
   }
 }
 

--- a/components/signal/signal-field.tsx
+++ b/components/signal/signal-field.tsx
@@ -87,7 +87,7 @@ uniform float uReveal;
 uniform float uEnergy;
 uniform float uSeed;
 uniform int   uAttrCount;
-uniform vec3  uAttr[8];
+uniform vec3  uAttr[10];
 
 ${NOISE}
 
@@ -110,7 +110,7 @@ void main() {
   vec2 flow = curl(p + uSeed, uTime) * (0.030 + 0.105 * chaos + 0.07 * uEnergy);
   flow += vec2(0.008 + 0.026 * chaos, -0.004);
 
-  for (int i = 0; i < 8; i++) {
+  for (int i = 0; i < 10; i++) {
     if (i >= uAttrCount) break;
     vec3 a = uAttr[i];
     vec2 ap = (a.xy - 0.5) * vec2(uAspect, 1.0);
@@ -140,7 +140,7 @@ void main() {
   hue = mix(hue, 0.0, min(emit * 6.0, 0.9));
 
   /* attractor emission */
-  for (int i = 0; i < 8; i++) {
+  for (int i = 0; i < 10; i++) {
     if (i >= uAttrCount) break;
     vec3 a = uAttr[i];
     vec2 ap = (a.xy - 0.5) * vec2(uAspect, 1.0);
@@ -403,7 +403,7 @@ export default function SignalField({
     const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1)
     const geometry = new THREE.PlaneGeometry(2, 2)
 
-    const attrs = Array.from({ length: 8 }, () => new THREE.Vector3())
+    const attrs = Array.from({ length: 10 }, () => new THREE.Vector3())
 
     const simMaterial = new THREE.ShaderMaterial({
       vertexShader: VERT,
@@ -560,7 +560,7 @@ export default function SignalField({
       simMaterial.uniforms.uEnergy.value = smoothEnergy
 
       const list = state.attractors
-      const count = Math.min(list.length, 8)
+      const count = Math.min(list.length, 10)
       for (let i = 0; i < count; i++) {
         attrs[i].set(list[i].x, 1 - list[i].y, list[i].strength)
       }

--- a/components/signal/signal-field.tsx
+++ b/components/signal/signal-field.tsx
@@ -1,0 +1,630 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import type { MutableRefObject } from 'react'
+import * as THREE from 'three'
+
+import type { SignalMask, SignalState } from './signal-types'
+import styles from './signal-field.module.css'
+
+/* ------------------------------------------------------------------ */
+/* shaders                                                            */
+/* ------------------------------------------------------------------ */
+
+const VERT = /* glsl */ `
+varying vec2 vUv;
+void main() {
+  vUv = uv;
+  gl_Position = vec4(position.xy, 0.0, 1.0);
+}
+`
+
+const NOISE = /* glsl */ `
+vec3 mod289(vec3 x) { return x - floor(x * (1.0 / 289.0)) * 289.0; }
+vec2 mod289(vec2 x) { return x - floor(x * (1.0 / 289.0)) * 289.0; }
+vec3 permute(vec3 x) { return mod289(((x * 34.0) + 1.0) * x); }
+
+float snoise(vec2 v) {
+  const vec4 C = vec4(0.211324865405187, 0.366025403784439,
+                     -0.577350269189626, 0.024390243902439);
+  vec2 i  = floor(v + dot(v, C.yy));
+  vec2 x0 = v -   i + dot(i, C.xx);
+  vec2 i1 = (x0.x > x0.y) ? vec2(1.0, 0.0) : vec2(0.0, 1.0);
+  vec4 x12 = x0.xyxy + C.xxzz;
+  x12.xy -= i1;
+  i = mod289(i);
+  vec3 p = permute(permute(i.y + vec3(0.0, i1.y, 1.0))
+                 + i.x + vec3(0.0, i1.x, 1.0));
+  vec3 m = max(0.5 - vec3(dot(x0, x0), dot(x12.xy, x12.xy),
+                          dot(x12.zw, x12.zw)), 0.0);
+  m = m * m; m = m * m;
+  vec3 x = 2.0 * fract(p * C.www) - 1.0;
+  vec3 h = abs(x) - 0.5;
+  vec3 ox = floor(x + 0.5);
+  vec3 a0 = x - ox;
+  m *= 1.79284291400159 - 0.85373472095314 * (a0 * a0 + h * h);
+  vec3 g;
+  g.x  = a0.x  * x0.x  + h.x  * x0.y;
+  g.yz = a0.yz * x12.xz + h.yz * x12.yw;
+  return 130.0 * dot(m, g);
+}
+
+float fbm(vec2 p) {
+  float v = 0.0;
+  float a = 0.5;
+  for (int i = 0; i < 4; i++) {
+    v += a * snoise(p);
+    p = p * 2.03 + 17.3;
+    a *= 0.5;
+  }
+  return v;
+}
+
+float hash21(vec2 p) {
+  p = fract(p * vec2(123.34, 456.21));
+  p += dot(p, p + 45.32);
+  return fract(p.x * p.y);
+}
+`
+
+/**
+ * Advection / feedback pass. Each frame the previous frame is dragged along a
+ * curl-noise flow field, decayed, and re-lit by the mask texture. The mask is
+ * sampled through a noise displacement scaled by (1 - reveal), so at reveal = 0
+ * the text is smeared into pure static and at reveal = 1 it locks into place.
+ */
+const SIM_FRAG = /* glsl */ `
+precision highp float;
+varying vec2 vUv;
+
+uniform sampler2D uPrev;
+uniform sampler2D uMask;
+uniform vec2  uRes;
+uniform float uAspect;
+uniform float uTime;
+uniform float uDt;
+uniform float uReveal;
+uniform float uEnergy;
+uniform float uSeed;
+uniform int   uAttrCount;
+uniform vec3  uAttr[8];
+
+${NOISE}
+
+vec2 curl(vec2 p, float t) {
+  float e = 0.06;
+  float n1 = fbm(vec2(p.x, p.y + e) * 1.15 + vec2(0.0, t * 0.05));
+  float n2 = fbm(vec2(p.x, p.y - e) * 1.15 + vec2(0.0, t * 0.05));
+  float n3 = fbm(vec2(p.x + e, p.y) * 1.15 + vec2(0.0, t * 0.05));
+  float n4 = fbm(vec2(p.x - e, p.y) * 1.15 + vec2(0.0, t * 0.05));
+  return vec2(n1 - n2, -(n3 - n4)) / (2.0 * e);
+}
+
+void main() {
+  vec2 uv = vUv;
+  vec2 p = (uv - 0.5) * vec2(uAspect, 1.0);
+
+  float calm = uReveal;
+  float chaos = 1.0 - calm;
+
+  vec2 flow = curl(p + uSeed, uTime) * (0.030 + 0.105 * chaos + 0.07 * uEnergy);
+  flow += vec2(0.008 + 0.026 * chaos, -0.004);
+
+  for (int i = 0; i < 8; i++) {
+    if (i >= uAttrCount) break;
+    vec3 a = uAttr[i];
+    vec2 ap = (a.xy - 0.5) * vec2(uAspect, 1.0);
+    vec2 d = ap - p;
+    float r = max(length(d), 0.0015);
+    float w = a.z * exp(-r * r * 9.0);
+    vec2 dir = d / r;
+    flow += (dir * 0.55 + vec2(-dir.y, dir.x) * 1.15) * w * (0.4 + 0.6 * uEnergy);
+  }
+
+  vec2 src = uv - flow * uDt / vec2(uAspect, 1.0);
+  vec4 prev = texture2D(uPrev, clamp(src, vec2(0.001), vec2(0.999)));
+
+  float v = prev.r * (0.9405 + 0.0245 * chaos);
+  float hue = prev.g;
+
+  /* mask emission, displaced while unresolved */
+  vec2 warp = vec2(
+    fbm(p * 2.1 + uSeed + uTime * 0.06),
+    fbm(p * 2.1 - uSeed - uTime * 0.05)
+  );
+  float jitter = hash21(uv * uRes + floor(uTime * 24.0)) - 0.5;
+  vec2 muv = uv + warp * chaos * 0.16 + jitter * chaos * 0.03;
+  float m = texture2D(uMask, clamp(muv, vec2(0.0), vec2(1.0))).r;
+  float emit = m * (0.05 + 0.235 * calm);
+  v += emit;
+  hue = mix(hue, 0.0, min(emit * 6.0, 0.9));
+
+  /* attractor emission */
+  for (int i = 0; i < 8; i++) {
+    if (i >= uAttrCount) break;
+    vec3 a = uAttr[i];
+    vec2 ap = (a.xy - 0.5) * vec2(uAspect, 1.0);
+    float r = length(ap - p);
+    float glow = a.z * exp(-r * r * 260.0) * 0.42;
+    v += glow;
+    hue = mix(hue, 0.35, min(glow * 5.0, 0.8));
+  }
+
+  /* noise floor: the carrier before it is tuned in */
+  float st = hash21(uv * uRes * 0.5 + floor(uTime * 30.0) * 1.37 + uSeed);
+  float sparkle = step(0.9968 - 0.016 * chaos, st);
+  v += sparkle * (0.07 + 0.44 * chaos);
+  hue = mix(hue, 1.0, sparkle * 0.85);
+
+  gl_FragColor = vec4(clamp(v, 0.0, 1.0), clamp(hue, 0.0, 1.0), 0.0, 1.0);
+}
+`
+
+const PRESENT_FRAG = /* glsl */ `
+precision highp float;
+varying vec2 vUv;
+
+uniform sampler2D uSim;
+uniform vec2 uTexel;
+uniform vec3 uColorA;
+uniform vec3 uColorB;
+uniform vec3 uCore;
+uniform float uOpacity;
+uniform float uGamma;
+uniform float uVignette;
+uniform float uCoreLo;
+
+void main() {
+  vec2 o = uTexel * 1.5;
+  vec4 c = texture2D(uSim, vUv) * 0.36;
+  c += texture2D(uSim, vUv + vec2( o.x, 0.0)) * 0.16;
+  c += texture2D(uSim, vUv + vec2(-o.x, 0.0)) * 0.16;
+  c += texture2D(uSim, vUv + vec2(0.0,  o.y)) * 0.16;
+  c += texture2D(uSim, vUv + vec2(0.0, -o.y)) * 0.16;
+
+  float v = clamp(c.r, 0.0, 1.0);
+  float hue = clamp(c.g, 0.0, 1.0);
+
+  vec3 col = mix(uColorA, uColorB, smoothstep(0.0, 1.0, hue));
+  col = mix(col, uCore, smoothstep(uCoreLo, 1.0, v));
+
+  float d = distance(vUv, vec2(0.5, 0.48));
+  float vig = mix(1.0, smoothstep(0.95, 0.18, d), uVignette);
+
+  float a = pow(v, uGamma) * uOpacity * vig;
+  gl_FragColor = vec4(col, clamp(a, 0.0, 1.0));
+}
+`
+
+/* ------------------------------------------------------------------ */
+/* mask rasteriser — typography becomes the emitter                    */
+/* ------------------------------------------------------------------ */
+
+const MASK_W = 900
+
+function drawMask(canvas: HTMLCanvasElement, mask: SignalMask, aspect: number) {
+  const w = MASK_W
+  const h = Math.max(180, Math.round(MASK_W / Math.max(aspect, 0.35)))
+  if (canvas.width !== w || canvas.height !== h) {
+    canvas.width = w
+    canvas.height = h
+  }
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return
+  ctx.clearRect(0, 0, w, h)
+  ctx.fillStyle = '#000'
+  ctx.fillRect(0, 0, w, h)
+
+  if (mask.nodes?.length) {
+    ctx.lineCap = 'round'
+    for (const [a, b] of mask.links ?? []) {
+      const na = mask.nodes[a]
+      const nb = mask.nodes[b]
+      if (!na || !nb) continue
+      const strength = Math.min(na.weight, nb.weight)
+      ctx.strokeStyle = `rgba(255,255,255,${0.16 + strength * 0.55})`
+      ctx.lineWidth = 1.8 + strength * 3.2
+      ctx.beginPath()
+      ctx.moveTo(na.x * w, na.y * h)
+      ctx.lineTo(nb.x * w, nb.y * h)
+      ctx.stroke()
+    }
+    for (const node of mask.nodes) {
+      const r = 7 + node.weight * 30
+      const grad = ctx.createRadialGradient(
+        node.x * w,
+        node.y * h,
+        0,
+        node.x * w,
+        node.y * h,
+        r
+      )
+      grad.addColorStop(0, `rgba(255,255,255,${0.65 + node.weight * 0.35})`)
+      grad.addColorStop(0.32, `rgba(255,255,255,${0.22 + node.weight * 0.4})`)
+      grad.addColorStop(1, 'rgba(255,255,255,0)')
+      ctx.fillStyle = grad
+      ctx.beginPath()
+      ctx.arc(node.x * w, node.y * h, r, 0, Math.PI * 2)
+      ctx.fill()
+    }
+  }
+
+  const word = mask.text?.trim()
+  if (word) {
+    const family =
+      '"Helvetica Neue", Helvetica, Arial, "Segoe UI", system-ui, sans-serif'
+    let size = Math.round(h * 0.34 * (mask.scale ?? 1))
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(ctx as any).letterSpacing = '0.07em'
+    } catch {
+      /* letterSpacing unsupported — tracking is cosmetic */
+    }
+    for (let i = 0; i < 14; i++) {
+      ctx.font = `800 ${size}px ${family}`
+      const measured = ctx.measureText(word).width
+      if (measured <= w * 0.84 || size <= 14) break
+      size = Math.round(size * Math.min(0.94, (w * 0.84) / measured))
+    }
+    const cx = w * (0.5 + (mask.ox ?? 0))
+    const cy = h * (0.5 + (mask.oy ?? 0)) - (mask.caption ? h * 0.04 : 0)
+    ctx.fillStyle = 'rgba(255,255,255,0.92)'
+    ctx.fillText(word, cx, cy)
+
+    if (mask.caption) {
+      ctx.font = `500 ${Math.max(11, Math.round(size * 0.13))}px ui-monospace, "SF Mono", Menlo, monospace`
+      ctx.fillStyle = 'rgba(255,255,255,0.5)'
+      ctx.fillText(mask.caption.toUpperCase(), cx, cy + size * 0.72)
+    }
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* palettes                                                            */
+/* ------------------------------------------------------------------ */
+
+const rgb = (hex: string) =>
+  new THREE.Vector3(
+    parseInt(hex.slice(1, 3), 16) / 255,
+    parseInt(hex.slice(3, 5), 16) / 255,
+    parseInt(hex.slice(5, 7), 16) / 255
+  )
+
+const PALETTE = {
+  dark: {
+    a: rgb('#3ad0bd'),
+    b: rgb('#6f63f0'),
+    core: rgb('#ecfffb'),
+    opacity: 0.92,
+    gamma: 1.05,
+    vignette: 0.55,
+    coreLo: 0.42
+  },
+  light: {
+    a: rgb('#0a7f6c'),
+    b: rgb('#3a32ab'),
+    core: rgb('#101c26'),
+    opacity: 0.52,
+    gamma: 1.3,
+    vignette: 0.22,
+    coreLo: 0.66
+  }
+} as const
+
+/* ------------------------------------------------------------------ */
+/* component                                                           */
+/* ------------------------------------------------------------------ */
+
+type Props = {
+  stateRef: MutableRefObject<SignalState>
+  mask: SignalMask
+  className?: string
+  /** multiplies the presented opacity, for quieter sections */
+  gain?: number
+}
+
+export default function SignalField({
+  stateRef,
+  mask,
+  className,
+  gain = 1
+}: Props) {
+  const hostRef = useRef<HTMLDivElement>(null)
+  const maskRef = useRef<SignalMask>(mask)
+  const gainRef = useRef(gain)
+  const apiRef = useRef<{
+    redrawMask: () => void
+    setGain: (g: number) => void
+  } | null>(null)
+
+  maskRef.current = mask
+  gainRef.current = gain
+
+  useEffect(() => {
+    apiRef.current?.redrawMask()
+  }, [mask])
+
+  useEffect(() => {
+    apiRef.current?.setGain(gain)
+  }, [gain])
+
+  useEffect(() => {
+    const host = hostRef.current
+    if (!host) return
+
+    const reduced =
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+
+    let renderer: THREE.WebGLRenderer
+    try {
+      renderer = new THREE.WebGLRenderer({
+        alpha: true,
+        antialias: false,
+        powerPreference: 'high-performance'
+      })
+    } catch {
+      host.dataset.failed = 'true'
+      return
+    }
+    if (!renderer.getContext()) {
+      host.dataset.failed = 'true'
+      return
+    }
+
+    renderer.outputColorSpace = THREE.LinearSRGBColorSpace
+    renderer.setClearColor(0x000000, 0)
+    const canvas = renderer.domElement
+    canvas.className = styles.canvas
+    canvas.setAttribute('aria-hidden', 'true')
+    host.appendChild(canvas)
+    host.dataset.ready = 'true'
+
+    const maskCanvas = document.createElement('canvas')
+    const maskTexture = new THREE.CanvasTexture(maskCanvas)
+    maskTexture.colorSpace = THREE.NoColorSpace
+    maskTexture.minFilter = THREE.LinearFilter
+    maskTexture.magFilter = THREE.LinearFilter
+    maskTexture.wrapS = THREE.ClampToEdgeWrapping
+    maskTexture.wrapT = THREE.ClampToEdgeWrapping
+
+    const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1)
+    const geometry = new THREE.PlaneGeometry(2, 2)
+
+    const attrs = Array.from({ length: 8 }, () => new THREE.Vector3())
+
+    const simMaterial = new THREE.ShaderMaterial({
+      vertexShader: VERT,
+      fragmentShader: SIM_FRAG,
+      depthTest: false,
+      depthWrite: false,
+      uniforms: {
+        uPrev: { value: null as THREE.Texture | null },
+        uMask: { value: maskTexture },
+        uRes: { value: new THREE.Vector2(1, 1) },
+        uAspect: { value: 1 },
+        uTime: { value: 0 },
+        uDt: { value: 1 },
+        uReveal: { value: 0 },
+        uEnergy: { value: 0 },
+        uSeed: { value: Math.random() * 40 },
+        uAttrCount: { value: 0 },
+        uAttr: { value: attrs }
+      }
+    })
+
+    const presentMaterial = new THREE.ShaderMaterial({
+      vertexShader: VERT,
+      fragmentShader: PRESENT_FRAG,
+      transparent: true,
+      depthTest: false,
+      depthWrite: false,
+      uniforms: {
+        uSim: { value: null as THREE.Texture | null },
+        uTexel: { value: new THREE.Vector2(1, 1) },
+        uColorA: { value: PALETTE.dark.a.clone() },
+        uColorB: { value: PALETTE.dark.b.clone() },
+        uCore: { value: PALETTE.dark.core.clone() },
+        uOpacity: { value: PALETTE.dark.opacity },
+        uGamma: { value: PALETTE.dark.gamma },
+        uVignette: { value: PALETTE.dark.vignette },
+        uCoreLo: { value: PALETTE.dark.coreLo }
+      }
+    })
+
+    const simScene = new THREE.Scene()
+    simScene.add(new THREE.Mesh(geometry, simMaterial))
+    const presentScene = new THREE.Scene()
+    presentScene.add(new THREE.Mesh(geometry, presentMaterial))
+
+    const makeTarget = (w: number, h: number) =>
+      new THREE.WebGLRenderTarget(w, h, {
+        minFilter: THREE.LinearFilter,
+        magFilter: THREE.LinearFilter,
+        format: THREE.RGBAFormat,
+        type: THREE.UnsignedByteType,
+        depthBuffer: false,
+        stencilBuffer: false,
+        wrapS: THREE.ClampToEdgeWrapping,
+        wrapT: THREE.ClampToEdgeWrapping
+      })
+
+    let targets: [THREE.WebGLRenderTarget, THREE.WebGLRenderTarget] = [
+      makeTarget(2, 2),
+      makeTarget(2, 2)
+    ]
+    let ping = 0
+    let aspect = 1
+    let baseOpacity = PALETTE.dark.opacity
+
+    const redrawMask = () => {
+      drawMask(maskCanvas, maskRef.current, aspect)
+      maskTexture.needsUpdate = true
+    }
+
+    const applyTheme = () => {
+      const isLight = !document.documentElement.classList.contains('dark')
+      const p = isLight ? PALETTE.light : PALETTE.dark
+      presentMaterial.uniforms.uColorA.value.copy(p.a)
+      presentMaterial.uniforms.uColorB.value.copy(p.b)
+      presentMaterial.uniforms.uCore.value.copy(p.core)
+      presentMaterial.uniforms.uGamma.value = p.gamma
+      presentMaterial.uniforms.uVignette.value = p.vignette
+      presentMaterial.uniforms.uCoreLo.value = p.coreLo
+      baseOpacity = p.opacity
+      presentMaterial.uniforms.uOpacity.value = baseOpacity * gainRef.current
+    }
+
+    const resize = () => {
+      const rect = host.getBoundingClientRect()
+      const w = Math.max(1, Math.round(rect.width))
+      const h = Math.max(1, Math.round(rect.height))
+      aspect = w / h
+
+      const dpr = Math.min(window.devicePixelRatio || 1, 1.5)
+      renderer.setPixelRatio(dpr)
+      renderer.setSize(w, h, false)
+
+      // the feedback buffer runs well below display resolution: silky, cheap
+      const simW = Math.max(240, Math.min(760, Math.round(w * 0.5)))
+      const simH = Math.max(160, Math.round(simW / Math.max(aspect, 0.35)))
+      if (targets[0].width !== simW || targets[0].height !== simH) {
+        targets.forEach((t) => t.dispose())
+        targets = [makeTarget(simW, simH), makeTarget(simW, simH)]
+      }
+      simMaterial.uniforms.uRes.value.set(simW, simH)
+      simMaterial.uniforms.uAspect.value = aspect
+      presentMaterial.uniforms.uTexel.value.set(1 / simW, 1 / simH)
+      redrawMask()
+    }
+
+    apiRef.current = {
+      redrawMask: () => {
+        redrawMask()
+      },
+      setGain: (g: number) => {
+        presentMaterial.uniforms.uOpacity.value = baseOpacity * g
+      }
+    }
+
+    applyTheme()
+    resize()
+
+    const themeObserver = new MutationObserver(applyTheme)
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class']
+    })
+
+    const resizeObserver = new ResizeObserver(resize)
+    resizeObserver.observe(host)
+
+    let visible = true
+    const io = new IntersectionObserver(
+      (entries) => {
+        visible = entries.some((entry) => entry.isIntersecting)
+      },
+      { rootMargin: '120px' }
+    )
+    io.observe(host)
+
+    let raf = 0
+    let last = performance.now()
+    let clock = 0
+    let smoothReveal = 0
+    let smoothEnergy = 0
+    let warm = reduced ? 0 : 0
+
+    const step = (dtSeconds: number) => {
+      const state = stateRef.current
+      const dt = Math.min(dtSeconds, 1 / 30)
+      clock += dt
+      smoothReveal += (state.reveal - smoothReveal) * Math.min(1, dt * 3.2)
+      smoothEnergy += (state.energy - smoothEnergy) * Math.min(1, dt * 4.5)
+
+      simMaterial.uniforms.uTime.value = clock
+      simMaterial.uniforms.uDt.value = dt * 60 * 0.016
+      simMaterial.uniforms.uReveal.value = smoothReveal
+      simMaterial.uniforms.uEnergy.value = smoothEnergy
+
+      const list = state.attractors
+      const count = Math.min(list.length, 8)
+      for (let i = 0; i < count; i++) {
+        attrs[i].set(list[i].x, 1 - list[i].y, list[i].strength)
+      }
+      simMaterial.uniforms.uAttrCount.value = count
+
+      const read = targets[ping]
+      const write = targets[1 - ping]
+      simMaterial.uniforms.uPrev.value = read.texture
+      renderer.setRenderTarget(write)
+      renderer.render(simScene, camera)
+      renderer.setRenderTarget(null)
+      ping = 1 - ping
+
+      presentMaterial.uniforms.uSim.value = write.texture
+      renderer.render(presentScene, camera)
+    }
+
+    if (reduced) {
+      // Settle to a still, fully-resolved frame — no animation loop at all.
+      stateRef.current.reveal = 1
+      smoothReveal = 1
+      for (let i = 0; i < 90; i++) step(1 / 60)
+      const settle = () => {
+        smoothReveal = 1
+        for (let i = 0; i < 40; i++) step(1 / 60)
+      }
+      apiRef.current = {
+        redrawMask: () => {
+          redrawMask()
+          settle()
+        },
+        setGain: (g: number) => {
+          presentMaterial.uniforms.uOpacity.value = baseOpacity * g
+          renderer.render(presentScene, camera)
+        }
+      }
+    } else {
+      const loop = (now: number) => {
+        raf = requestAnimationFrame(loop)
+        const dt = (now - last) / 1000
+        last = now
+        if (!visible || document.hidden) return
+        if (warm < 45) {
+          warm += 1
+          step(1 / 60)
+        }
+        step(dt || 1 / 60)
+      }
+      raf = requestAnimationFrame(loop)
+    }
+
+    return () => {
+      cancelAnimationFrame(raf)
+      io.disconnect()
+      resizeObserver.disconnect()
+      themeObserver.disconnect()
+      apiRef.current = null
+      targets.forEach((t) => t.dispose())
+      geometry.dispose()
+      simMaterial.dispose()
+      presentMaterial.dispose()
+      maskTexture.dispose()
+      renderer.dispose()
+      renderer.forceContextLoss()
+      canvas.remove()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <div
+      ref={hostRef}
+      className={`${styles.host} ${className ?? ''}`}
+      aria-hidden="true"
+    />
+  )
+}

--- a/components/signal/signal-field.tsx
+++ b/components/signal/signal-field.tsx
@@ -292,7 +292,17 @@ const rgb = (hex: string) =>
     parseInt(hex.slice(5, 7), 16) / 255
   )
 
-const PALETTE = {
+type Palette = {
+  a: THREE.Vector3
+  b: THREE.Vector3
+  core: THREE.Vector3
+  opacity: number
+  gamma: number
+  vignette: number
+  coreLo: number
+}
+
+const PALETTE: Record<'dark' | 'light', Palette> = {
   dark: {
     a: rgb('#3ad0bd'),
     b: rgb('#6f63f0'),
@@ -311,7 +321,7 @@ const PALETTE = {
     vignette: 0.22,
     coreLo: 0.66
   }
-} as const
+}
 
 /* ------------------------------------------------------------------ */
 /* component                                                           */

--- a/components/signal/signal-types.ts
+++ b/components/signal/signal-types.ts
@@ -1,0 +1,47 @@
+export type SignalNode = {
+  /** normalised 0..1 horizontal position within the field */
+  x: number
+  /** normalised 0..1 vertical position within the field */
+  y: number
+  /** 0..1 emission weight */
+  weight: number
+}
+
+export type SignalMask = {
+  /** big word burned into the field; the field emits from its glyphs */
+  text?: string
+  /** small caption burned under the word */
+  caption?: string
+  /** point emitters — used by the systems topology */
+  nodes?: SignalNode[]
+  /** index pairs describing links between nodes */
+  links?: [number, number][]
+  /** normalised offset of the burned word from centre, -0.5..0.5 */
+  ox?: number
+  oy?: number
+  /** relative scale of the burned word */
+  scale?: number
+}
+
+export type SignalAttractor = {
+  x: number
+  y: number
+  /** pull + emission strength, 0..1 */
+  strength: number
+  /** rotational bias, -1..1 */
+  spin: number
+}
+
+export type SignalState = {
+  /** 0 = pure noise, 1 = fully locked signal */
+  reveal: number
+  /** extra turbulence injected by interaction, 0..1 */
+  energy: number
+  attractors: SignalAttractor[]
+}
+
+export const createSignalState = (): SignalState => ({
+  reveal: 0,
+  energy: 0,
+  attractors: []
+})


### PR DESCRIPTION
## Option 3 of 3 — "Signal"

**The art piece.** *"A résumé is a compressed signal."*

### The engine
One custom WebGL feedback-field shared by both pages. A ping-pong buffer advects the previous frame along a curl-noise flow and re-lights it from a mask rasterised on an offscreen 2D canvas — so **typography is the emitter**. A `reveal` uniform scrubs mask sampling through a noise displacement: at 0 the word is pure static, at 1 it locks.

### /career — scroll is the tuning dial
Seven transmissions, each burning its own word into the field and resolving as it centres, with a mono lock-strength HUD:

`HALLER` → `APPLE` (chatbot, 2018–2020) → `CHICK-FIL-A` (2020–2022) → `SOLO` (~2022–2024, only engineer on Apple's cloud-resource UI) → `PORTAL` (~2024–present) → `SEVEN YEARS` ("One firm since 2018. They keep handing me the hard thing.") → `RANGE` → `OPEN`.

### /systems — "The stack is not a ladder. It is a field of forces."
Same engine, topology mask. Nine capabilities are literal attractors in the flow — hold one and the field reorganises around it. The words never move.

### The copy
The strongest writing of the three. On Chick-fil-A: *"DoorDash, UberEats and Grubhub arrive as three different opinions about what an order is, and have to resolve into one system that a restaurant can actually run on."* And: *"at that volume the question is never 'is something broken', it is 'whose'."*

### Technical
- Legibility is never traded for effect — every word is ordinary DOM text, in order, whether or not the field is running. Verified with **JS disabled**.
- `prefers-reduced-motion` renders a still, fully-resolved frame with no rAF loop.
- Dark = emission on ink. Light = a deliberate teal/rust risograph on bone paper — authored, not an inversion.

---

## Shared context across all three PRs

These three branches are **competing alternatives**, all forked from `codex/refine-portfolio-experiences` at `0785351`. Pick one; the other two can be closed.

### The premise fix
The previous pages framed the Apple and Chick-fil-A engagements as **embedded engineering** and made "embedded systems" the career through-line. Per Devon's own résumés, that is not accurate — both were backend / full-stack platform and third-party integration work at consumer scale. Every branch strips that framing.

### The story that was missing
Apple is not a single 2018–2020 engagement. It is a **seven-year relationship across three eras**, under one firm — Stellar Elements (formerly Big Nerd Ranch), an Amdocs company, July 2018 → present:

| Period | Engagement | Role |
| --- | --- | --- |
| 2024 → present | Apple — internal cloud site → developer portal | Product engineer, React + TypeScript |
| 2022 → 2024 | Apple — third-party cloud resource UI | **Sole engineer, two years** |
| 2020 → 2022 | Chick-fil-A — third-party delivery (DoorDash/UberEats/Grubhub) | Project engineering lead |
| 2018 → 2020 | Apple — chatbot platform | Backend lead |

Verified numbers now used as content: 1M → 15M users at 100% uptime · 60s → 2s page load · Node 5 → 12 · Angular 1 → Vue · &lt;$1M → $5M per day through Covid · ~10% higher AOV from UberEats combo meals · AWS CloudFormation migration.

Positioning target: **Product Engineer**.

### Known repo issues found (pre-existing, NOT introduced here)
- `app/layout.tsx` hardcodes `<html className="dark">` and never mounts `ThemeProvider`, so **light mode is unreachable site-wide** even though `next-themes` is installed. All three branches author and verify light mode anyway, so it works as soon as the toggle is wired.
- `npx eslint` fails repo-wide on an `eslint-config-next` ↔ `zod` exports conflict, so lint is currently a no-op. Reproduces on untouched files.

### Still open before publishing
- Exact start/end **months** for the two recent Apple eras.
- **Current title** — pages still carry "Solutions Architect" from the 2022 résumé.
- `/resume.pdf` is linked but the asset does not exist yet.

Untouched: `/orbital`, `/blog`, `/directions`. `npx contentlayer2 build && npx next build` passes on every branch.
